### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# OmniLend.pro
+
+This repository contains the static website for **OMNILend.pro**. It is written entirely with vanilla HTML, CSS and JavaScript and includes a small API function for forwarding contact form submissions to Telegram.
+
+## Running Locally
+
+1. Clone the repository and navigate to the project directory.
+2. Serve the static files using any HTTP server. For example:
+
+```bash
+# Using the Node.js `serve` package
+npx serve .
+
+# Or using Python
+python3 -m http.server
+```
+
+Open the displayed URL in your browser to access the site.
+
+## Environment Variables
+
+The contact form posts to `/api/sendMessage`, which relies on two environment variables:
+
+- `TELEGRAM_BOT_TOKEN` – your Telegram bot token.
+- `TELEGRAM_CHAT_ID` – the chat ID that should receive the messages.
+
+Set these variables in your hosting environment (or in a `.env` file if supported) so `api/sendMessage.js` can send messages to your Telegram account.
+
+## Hosting Updates
+
+Because this is a static site, updates do not appear until you redeploy or otherwise replace the hosted files. After pushing changes, trigger a new deployment on your hosting provider (for example Netlify, Vercel or any static server) so the latest files are served.
+


### PR DESCRIPTION
## Summary
- add README detailing how to run the static site
- document TELEGRAM_* environment variables for the sendMessage API
- explain redeploy requirement for hosting updates

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866a396533c8333a72f45a45df5b999