### PR TITLE
Add .gitignore for Node and OS artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Node dependencies
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+.env.*
+
+# Build artifacts
+build/
+dist/
+coverage/
+*.log
+*.tmp
+*.temp
+tmp/
+
+# Others
+*.swp


### PR DESCRIPTION
## Summary
- add a basic `.gitignore` to omit node modules, build output, logs, and OS-specific files

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866a39ac1ac83338e624d5cbe963223