### PR TITLE
Remove stray word from page headers

### DIFF
--- a/Contact.html
+++ b/Contact.html
@@ -10,7 +10,6 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
- main
 </head>
 <body>
     <div class="wrapper">

--- a/Inventory.html
+++ b/Inventory.html
@@ -10,7 +10,6 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
- main
 </head>
 <body>
     <div class="wrapper">

--- a/Qualify.html
+++ b/Qualify.html
@@ -10,7 +10,6 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
- main
 </head>
 <body>
     <div class="wrapper">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">
- main
 </head>
 <body>
     <div class="wrapper">


### PR DESCRIPTION
## Summary
- clean up stray `main` text that showed up in the `<head>` of every page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866ac6695a08333909b6e7227e69b2f