### PR TITLE
Add security division experience and selector

### DIFF
--- a/contact.js
+++ b/contact.js
@@ -1,42 +1,48 @@
-const contactForm = document.getElementById('contactForm');
-if (contactForm) {
-    contactForm.addEventListener('submit', async (e) => {
-        e.preventDefault();
+const forms = Array.from(document.querySelectorAll('[data-contact-form]'));
 
-        const formStatus = document.getElementById('formStatus');
-        const submitBtn = contactForm.querySelector('button[type="submit"]');
-        if (submitBtn) submitBtn.disabled = true;
-        if (formStatus) formStatus.textContent = 'Sending your project details…';
+if (forms.length) {
+    forms.forEach((form) => {
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
 
-        const payload = {
-            name: document.getElementById('name').value.trim(),
-            email: document.getElementById('email').value.trim(),
-            service: document.getElementById('service') ? document.getElementById('service').value : '',
-            budget: document.getElementById('budget') ? document.getElementById('budget').value : '',
-            message: document.getElementById('message').value.trim()
-        };
+            const statusEl = form.querySelector('[data-form-status]');
+            const submitBtn = form.querySelector('button[type="submit"]');
+            if (submitBtn) submitBtn.disabled = true;
+            if (statusEl) statusEl.textContent = 'Sending your request…';
 
-        try {
-            const response = await fetch('/api/sendMessage', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
+            const formData = new FormData(form);
+            const payload = {};
+            formData.forEach((value, key) => {
+                if (typeof value === 'string') {
+                    payload[key] = value.trim();
+                } else {
+                    payload[key] = value;
+                }
             });
+            payload.experience = form.getAttribute('data-experience') || 'general';
 
-            const result = await response.json().catch(() => ({}));
+            try {
+                const response = await fetch('/api/sendMessage', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
 
-            if (response.ok) {
-                if (formStatus) formStatus.textContent = 'Thanks! Your note is en route to our Telegram inbox.';
-                contactForm.reset();
-            } else {
-                const msg = result.message || 'We could not deliver your message. Please try again shortly.';
-                if (formStatus) formStatus.textContent = msg;
+                const result = await response.json().catch(() => ({}));
+
+                if (response.ok) {
+                    if (statusEl) statusEl.textContent = 'Thanks! Your note is en route to our Telegram inbox.';
+                    form.reset();
+                } else {
+                    const msg = result.message || 'We could not deliver your message. Please try again shortly.';
+                    if (statusEl) statusEl.textContent = msg;
+                }
+            } catch (error) {
+                console.error('Contact form error:', error);
+                if (statusEl) statusEl.textContent = 'We hit a network issue sending to Telegram. Please try again.';
+            } finally {
+                if (submitBtn) submitBtn.disabled = false;
             }
-        } catch (error) {
-            console.error('Contact form error:', error);
-            if (formStatus) formStatus.textContent = 'We hit a network issue sending to Telegram. Please try again.';
-        } finally {
-            if (submitBtn) submitBtn.disabled = false;
-        }
+        });
     });
 }

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Ømnilon Interiors | Home</title>
+    <title>Ømnilon | Choose Your Division</title>
     <link rel="stylesheet" href="style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Ømnilon Interiors — Atlanta-based interior design studio offering e-design, residential refresh, staging, and small commercial projects.">
+    <meta name="description" content="Ømnilon — Choose between our award-winning interior studio and our new security intelligence division." />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -13,203 +13,403 @@
 </head>
 <body class="theme-jeton">
     <div id="scrollProgress"></div>
-    <div class="wrapper">
-        <header class="brand-header reveal fade is-visible">
-            <a href="#home" class="brand" aria-label="Ømnilon Interiors">
-                <span class="brand-title">ØMNILON</span>
-            </a>
-            <button id="menuToggle" class="menu-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="siteNav">
-                <span></span><span></span><span></span>
-            </button>
-        </header>
-        <nav id="siteNav">
-            <a href="#home" class="active">Home</a>
-            <a href="#services">Services</a>
-            <a href="#portfolio">Portfolio</a>
-            <a href="#about">About</a>
-            <a href="#contact">Contact</a>
-        </nav>
 
-        <main class="onepage">
-            <!-- Jeton-style dark hero -->
-            <section id="home" class="hero-jeton hero reveal fx-clip" style="position:relative;">
-                <div class="bg-grid"></div>
-                <div class="orb orb-1" data-parallax-y="0.06"></div>
-                <div class="orb orb-2" data-parallax-y="0.1"></div>
-                <video id="heroVideo" class="hero-video" playsinline muted loop preload="metadata" poster="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1600&auto=format&fit=crop" data-img="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&w=1600&auto=format&fit=crop" data-src="https://videos.pexels.com/video-files/2934978/2934978-uhd_3840_2160_24fps.mp4"></video>
-                <div class="hero-inner fx-rise" data-parallax="0.12">
-                    <h1 class="grad-text">Design that works as beautifully as it looks.</h1>
-                    <p>We combine material expertise with modern process to deliver interiors that feel intentional, calm, and effortless.</p>
+    <div id="experienceSelector" class="experience-selector" aria-labelledby="experienceTitle">
+        <div class="selector-inner reveal fx-rise">
+            <span class="selector-badge">ØMNILON</span>
+            <h1 id="experienceTitle">Select your experience</h1>
+            <p class="selector-copy">One house, two disciplines. Choose interiors for calm spatial design, or security to uncover profit-eating vulnerabilities with our Secret Lifters.</p>
+            <div class="selector-grid">
+                <button class="selector-card" data-target="interiors">
+                    <span class="selector-heading">Ømnilon Interiors</span>
+                    <span class="selector-text">Intentional residential, staging, and boutique spaces delivered with a modern, transparent process.</span>
+                    <span class="selector-cta">Enter the design studio</span>
+                </button>
+                <button class="selector-card" data-target="security">
+                    <span class="selector-heading">Ømnilon Security</span>
+                    <span class="selector-text">Our new asset protection intelligence unit. Secret Lifters simulate organized theft—online and in-store—so you can close the gaps first.</span>
+                    <span class="selector-cta">Deploy a Secret Lifter</span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <noscript>
+        <style>
+            .experience-selector { display:none !important; }
+            .experience[hidden] { display:block !important; }
+        </style>
+        <div class="noscript-warning">Enable JavaScript to switch between Ømnilon divisions.</div>
+    </noscript>
+
+    <div id="interiorsExperience" class="experience experience-interiors" hidden aria-hidden="true">
+        <div class="wrapper">
+            <header class="brand-header reveal fade">
+                <a href="#home" class="brand" aria-label="Ømnilon Interiors">
+                    <span class="brand-title">ØMNILON</span>
+                </a>
+                <div class="header-actions">
+                    <button class="experience-pill" data-switch-experience="security">Explore Security</button>
+                    <button id="menuToggle" class="menu-toggle" data-menu-toggle="siteNav" data-menu-class="nav-open" aria-label="Open menu" aria-expanded="false" aria-controls="siteNav">
+                        <span></span><span></span><span></span>
+                    </button>
+                </div>
+            </header>
+            <nav id="siteNav">
+                <a href="#home" class="active">Home</a>
+                <a href="#services">Services</a>
+                <a href="#portfolio">Portfolio</a>
+                <a href="#about">About</a>
+                <a href="#contact">Contact</a>
+            </nav>
+
+            <main class="onepage">
+                <section id="home" class="hero-jeton hero reveal fx-clip" style="position:relative;">
+                    <div class="bg-grid"></div>
+                    <div class="orb orb-1" data-parallax-y="0.06"></div>
+                    <div class="orb orb-2" data-parallax-y="0.1"></div>
+                    <video id="heroVideo" class="hero-video" playsinline muted loop preload="metadata" poster="https://images.unsplash.com/photo-1497366216548-37526070297c?q=80&w=1600&auto=format&fit=crop" data-img="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&w=1600&auto=format&fit=crop" data-src="https://videos.pexels.com/video-files/2934978/2934978-uhd_3840_2160_24fps.mp4"></video>
+                    <div class="hero-inner fx-rise" data-parallax="0.12">
+                        <h1 class="grad-text">Design that works as beautifully as it looks.</h1>
+                        <p>We combine material expertise with modern process to deliver interiors that feel intentional, calm, and effortless.</p>
+                        <div class="cta-row">
+                            <a class="btn btn-jeton" href="#contact">Start a project</a>
+                            <a class="btn btn-outline" href="#portfolio">See work</a>
+                        </div>
+                    </div>
+                    <div class="mock-window reveal from-right" aria-hidden="true">
+                        <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&w=1600&auto=format&fit=crop" alt="Project preview" loading="lazy" />
+                    </div>
+                    <a class="scroll-cue" href="#services" aria-label="Scroll to content"></a>
+                </section>
+
+                <section id="services" class="section feature-grid stagger features-jeton" data-stagger-step="0.08">
+                    <article class="feature jeton-card fx-rise">
+                        <h3>E-Design</h3>
+                        <p>Fast, flat-fee design boards with links, finish schedules, and a shopping list you can execute at your pace.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Residential Refresh</h3>
+                        <p>Room-by-room transformations with milestone billing. Client funds purchases so you never float materials.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Staging</h3>
+                        <p>Photo-ready staging that highlights your property’s strengths. Clear terms on inventory, timing, and care.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Small Commercial</h3>
+                        <p>Warm, durable finishes and layouts for boutiques, coffee shops, and creative offices.</p>
+                    </article>
+                </section>
+
+                <section id="portfolio" class="section gallery-grid features-jeton">
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1505691723518-36a5ac3b2a59?q=80&w=1600&auto=format&fit=crop" alt="Warm modern living room"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1493666438817-866a91353ca9?q=80&w=1600&auto=format&fit=crop" alt="Minimal kitchen detail"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1600&auto=format&fit=crop" alt="Bedroom with natural textures"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1493809842364-78817add7ffb?q=80&w=1600&auto=format&fit=crop" alt="Light-filled dining area"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1524758631624-e2822e304c36?q=80&w=1600&auto=format&fit=crop" alt="Timeless bathroom finishes"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1521783988139-893ceae1bfb0?q=80&w=1600&auto=format&fit=crop" alt="Entryway styling"></figure>
+                </section>
+
+                <section id="about" class="section process reveal">
+                    <h2>How We Work</h2>
+                    <ol>
+                        <li>Discovery call and style fit</li>
+                        <li>Design concepts and selections</li>
+                        <li>Procurement with client-funded purchasing</li>
+                        <li>Install and final styling</li>
+                    </ol>
+                </section>
+
+                <section id="principles" class="section principles fx-rise">
+                    <h2>Principles</h2>
+                    <div class="principles-grid">
+                        <div class="p-card"><h4>Human</h4><p>Spaces that support daily life and rituals.</p></div>
+                        <div class="p-card"><h4>Material</h4><p>Durable finishes that age beautifully.</p></div>
+                        <div class="p-card"><h4>Clarity</h4><p>Simple scopes, clear budgets, no surprises.</p></div>
+                        <div class="p-card"><h4>Momentum</h4><p>Deposits + milestones keep projects on time.</p></div>
+                    </div>
+                </section>
+
+                <section id="testimonials" class="section testimonials fx-clip">
+                    <div class="testimonials-head fx-rise">
+                        <h2>What clients say</h2>
+                        <p class="t-sub">Calm, detail-led interiors that make everyday moments feel refined.</p>
+                    </div>
+                    <div class="carousel" data-carousel>
+                        <button class="c-prev" aria-label="Previous testimonial">‹</button>
+                        <div class="c-track" id="testimonialTrack" data-src="data/testimonials.json">
+                            <article class="t-card fx-rise">
+                                <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
+                                <span class="sr-only">Rated 5 out of 5</span>
+                                <p class="t-quote">Absolutely transformed our living room. Calm, warm, and practical.</p>
+                                <div class="t-meta">
+                                    <img class="t-avatar" src="https://images.unsplash.com/photo-1544725176-7c40e5a2c9f9?q=80&w=256&auto=format&fit=crop" alt="Portrait of A. Rivera" loading="lazy" />
+                                    <div>
+                                        <strong>A. Rivera</strong>
+                                        <span class="t-role">Homeowner</span>
+                                    </div>
+                                </div>
+                            </article>
+                            <article class="t-card fx-rise">
+                                <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
+                                <span class="sr-only">Rated 5 out of 5</span>
+                                <p class="t-quote">Clear milestones and great communication. Install day felt effortless.</p>
+                                <div class="t-meta">
+                                    <img class="t-avatar" src="https://images.unsplash.com/photo-1531123414780-f742d16b5b2d?q=80&w=256&auto=format&fit=crop" alt="Portrait of L. Greene" loading="lazy" />
+                                    <div>
+                                        <strong>L. Greene</strong>
+                                        <span class="t-role">Townhome Renovation</span>
+                                    </div>
+                                </div>
+                            </article>
+                            <article class="t-card fx-rise">
+                                <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
+                                <span class="sr-only">Rated 5 out of 5</span>
+                                <p class="t-quote">We booked e-design first, then brought Ømnilon for full staging.</p>
+                                <div class="t-meta">
+                                    <img class="t-avatar" src="https://images.unsplash.com/photo-1527980965255-d3b416303d12?q=80&w=256&auto=format&fit=crop" alt="Portrait of M. Patel" loading="lazy" />
+                                    <div>
+                                        <strong>M. Patel</strong>
+                                        <span class="t-role">Realtor Partner</span>
+                                    </div>
+                                </div>
+                            </article>
+                        </div>
+                        <button class="c-next" aria-label="Next testimonial">›</button>
+                    </div>
+                </section>
+
+                <section class="section cta-stripe fx-rise">
+                    <h3>Ready to start?</h3>
+                    <p>Tell us about your project and get a tailored plan in 24 hours.</p>
                     <div class="cta-row">
                         <a class="btn btn-jeton" href="#contact">Start a project</a>
-                        <a class="btn btn-outline" href="#portfolio">See work</a>
+                        <a class="btn btn-outline" href="Payment.html">Make a payment</a>
                     </div>
-                </div>
-                <div class="mock-window reveal from-right" aria-hidden="true">
-                    <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?q=80&w=1600&auto=format&fit=crop" alt="Project preview" loading="lazy" />
-                </div>
-                <a class="scroll-cue" href="#services" aria-label="Scroll to content"></a>
-            </section>
+                </section>
 
-            <!-- Services -->
-            <section id="services" class="section feature-grid stagger features-jeton" data-stagger-step="0.08">
-                <article class="feature jeton-card fx-rise">
-                    <h3>E-Design</h3>
-                    <p>Fast, flat-fee design boards with links, finish schedules, and a shopping list you can execute at your pace.</p>
-                </article>
-                <article class="feature jeton-card fx-rise">
-                    <h3>Residential Refresh</h3>
-                    <p>Room-by-room transformations with milestone billing. Client funds purchases so you never float materials.</p>
-                </article>
-                <article class="feature jeton-card fx-rise">
-                    <h3>Staging</h3>
-                    <p>Photo-ready staging that highlights your property’s strengths. Clear terms on inventory, timing, and care.</p>
-                </article>
-                <article class="feature jeton-card fx-rise">
-                    <h3>Small Commercial</h3>
-                    <p>Warm, durable finishes and layouts for boutiques, coffee shops, and creative offices.</p>
-                </article>
-            </section>
-
-            <!-- Portfolio -->
-            <section id="portfolio" class="section gallery-grid features-jeton">
-                <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1505691723518-36a5ac3b2a59?q=80&w=1600&auto=format&fit=crop" alt="Warm modern living room"></figure>
-                <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1493666438817-866a91353ca9?q=80&w=1600&auto=format&fit=crop" alt="Minimal kitchen detail"></figure>
-                <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1501045661006-fcebe0257c3f?q=80&w=1600&auto=format&fit=crop" alt="Bedroom with natural textures"></figure>
-                <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1493809842364-78817add7ffb?q=80&w=1600&auto=format&fit=crop" alt="Light-filled dining area"></figure>
-                <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1524758631624-e2822e304c36?q=80&w=1600&auto=format&fit=crop" alt="Timeless bathroom finishes"></figure>
-                <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1521783988139-893ceae1bfb0?q=80&w=1600&auto=format&fit=crop" alt="Entryway styling"></figure>
-            </section>
-
-            <!-- About / Process -->
-            <section id="about" class="section process reveal">
-                <h2>How We Work</h2>
-                <ol>
-                    <li>Discovery call and style fit</li>
-                    <li>Design concepts and selections</li>
-                    <li>Procurement with client-funded purchasing</li>
-                    <li>Install and final styling</li>
-                </ol>
-            </section>
-
-            <!-- Principles -->
-            <section id="principles" class="section principles fx-rise">
-                <h2>Principles</h2>
-                <div class="principles-grid">
-                    <div class="p-card"><h4>Human</h4><p>Spaces that support daily life and rituals.</p></div>
-                    <div class="p-card"><h4>Material</h4><p>Durable finishes that age beautifully.</p></div>
-                    <div class="p-card"><h4>Clarity</h4><p>Simple scopes, clear budgets, no surprises.</p></div>
-                    <div class="p-card"><h4>Momentum</h4><p>Deposits + milestones keep projects on time.</p></div>
-                </div>
-            </section>
-
-            <!-- Testimonials / Carousel -->
-            <section id="testimonials" class="section testimonials fx-clip">
-                <div class="testimonials-head fx-rise">
-                    <h2>What clients say</h2>
-                    <p class="t-sub">Calm, detail-led interiors that make everyday moments feel refined.</p>
-                </div>
-                <div class="carousel" data-carousel>
-                    <button class="c-prev" aria-label="Previous testimonial">‹</button>
-                    <div class="c-track" id="testimonialTrack" data-src="data/testimonials.json">
-                        <article class="t-card fx-rise">
-                            <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
-                            <span class="sr-only">Rated 5 out of 5</span>
-                            <p class="t-quote">Absolutely transformed our living room. Calm, warm, and practical.</p>
-                            <div class="t-meta">
-                                <img class="t-avatar" src="https://images.unsplash.com/photo-1544725176-7c40e5a2c9f9?q=80&w=256&auto=format&fit=crop" alt="Portrait of A. Rivera" loading="lazy" />
-                                <div>
-                                    <strong>A. Rivera</strong>
-                                    <span class="t-role">Homeowner</span>
-                                </div>
-                            </div>
-                        </article>
-                        <article class="t-card fx-rise">
-                            <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
-                            <span class="sr-only">Rated 5 out of 5</span>
-                            <p class="t-quote">Clear milestones and great communication. Install day felt effortless.</p>
-                            <div class="t-meta">
-                                <img class="t-avatar" src="https://images.unsplash.com/photo-1531123414780-f742d16b5b2d?q=80&w=256&auto=format&fit=crop" alt="Portrait of L. Greene" loading="lazy" />
-                                <div>
-                                    <strong>L. Greene</strong>
-                                    <span class="t-role">Townhome Renovation</span>
-                                </div>
-                            </div>
-                        </article>
-                        <article class="t-card fx-rise">
-                            <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
-                            <span class="sr-only">Rated 5 out of 5</span>
-                            <p class="t-quote">We booked e-design first, then brought Ømnilon for full staging.</p>
-                            <div class="t-meta">
-                                <img class="t-avatar" src="https://images.unsplash.com/photo-1527980965255-d3b416303d12?q=80&w=256&auto=format&fit=crop" alt="Portrait of M. Patel" loading="lazy" />
-                                <div>
-                                    <strong>M. Patel</strong>
-                                    <span class="t-role">Realtor Partner</span>
-                                </div>
-                            </div>
-                        </article>
-                    </div>
-                    <button class="c-next" aria-label="Next testimonial">›</button>
-                </div>
-            </section>
-
-            <!-- Final CTA Stripe -->
-            <section class="section cta-stripe fx-rise">
-                <h3>Ready to start?</h3>
-                <p>Tell us about your project and get a tailored plan in 24 hours.</p>
-                <div class="cta-row">
-                    <a class="btn btn-jeton" href="#contact">Start a project</a>
-                    <a class="btn btn-outline" href="Payment.html">Make a payment</a>
-                </div>
-            </section>            <!-- Contact -->
-            <section id="contact" class="section contact-form reveal">
-                <h2>Let’s talk about your space</h2>
-                <form id="contactForm">
-                    <label for="name">Name:</label>
-                    <input type="text" id="name" name="name" required>
-                    <label for="email">Email:</label>
-                    <input type="email" id="email" name="email" required>
-                    <label for="service">Service:</label>
-                    <select id="service" name="service">
-                        <option value="E-Design">E-Design</option>
-                        <option value="Residential Refresh">Residential Refresh</option>
-                        <option value="Staging">Staging</option>
-                        <option value="Small Commercial">Small Commercial</option>
-                        <option value="Unsure">Unsure</option>
-                    </select>
-                    <label for="budget">Budget Range:</label>
-                    <select id="budget" name="budget">
-                        <option value="Under $1,000">Under $1,000</option>
-                        <option value="$1,000–$3,000">$1,000–$3,000</option>
-                        <option value="$3,000–$7,500">$3,000–$7,500</option>
-                        <option value="$7,500+">$7,500+</option>
-                    </select>
-                    <label for="message">Project details:</label>
-                    <textarea id="message" name="message" placeholder="Scope, timeline, and any links (Pinterest, Instagram, etc.)" required></textarea>
-                    <button type="submit" class="btn btn-jeton">Submit</button>
-                </form>
-                <p id="formStatus" aria-live="polite" role="status"></p>
-                <ul style="margin-top:12px;">
-                    <li>Email: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
-                    <li>Phone: <a href="tel:4049198026">404-919-8026</a></li>
-                    <li>Hours: Mon–Fri, 8am–6pm ET</li>
-                </ul>
-            </section>
-        </main>
+                <section id="contact" class="section contact-form reveal">
+                    <h2>Let’s talk about your space</h2>
+                    <form id="interiorsContactForm" data-contact-form data-experience="interiors">
+                        <label for="interiorName">Name:</label>
+                        <input type="text" id="interiorName" name="name" required>
+                        <label for="interiorEmail">Email:</label>
+                        <input type="email" id="interiorEmail" name="email" required>
+                        <label for="interiorService">Service:</label>
+                        <select id="interiorService" name="service">
+                            <option value="E-Design">E-Design</option>
+                            <option value="Residential Refresh">Residential Refresh</option>
+                            <option value="Staging">Staging</option>
+                            <option value="Small Commercial">Small Commercial</option>
+                            <option value="Unsure">Unsure</option>
+                        </select>
+                        <label for="interiorBudget">Budget Range:</label>
+                        <select id="interiorBudget" name="budget">
+                            <option value="Under $1,000">Under $1,000</option>
+                            <option value="$1,000–$3,000">$1,000–$3,000</option>
+                            <option value="$3,000–$7,500">$3,000–$7,500</option>
+                            <option value="$7,500+">$7,500+</option>
+                        </select>
+                        <label for="interiorMessage">Project details:</label>
+                        <textarea id="interiorMessage" name="message" placeholder="Scope, timeline, and any links (Pinterest, Instagram, etc.)" required></textarea>
+                        <button type="submit" class="btn btn-jeton">Submit</button>
+                    </form>
+                    <p class="form-status" data-form-status aria-live="polite" role="status"></p>
+                    <ul class="contact-meta">
+                        <li>Email: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
+                        <li>Phone: <a href="tel:4049198026">404-919-8026</a></li>
+                        <li>Hours: Mon–Fri, 8am–6pm ET</li>
+                    </ul>
+                </section>
+            </main>
+        </div>
+        <footer class="site-footer">
+            <p>&copy; 2025 Ømnilon Interiors — Atlanta, GA</p>
+        </footer>
     </div>
-    <footer class="site-footer">
-        <p>&copy; 2025 Ømnilon Interiors — Atlanta, GA</p>
-    </footer>
 
-    <!-- Scripts -->
+    <div id="securityExperience" class="experience experience-security" hidden aria-hidden="true">
+        <div class="wrapper">
+            <header class="brand-header reveal fade">
+                <a href="#security-home" class="brand" aria-label="Ømnilon Security">
+                    <span class="brand-title">ØMNILON</span>
+                </a>
+                <div class="header-actions">
+                    <button class="experience-pill" data-switch-experience="interiors">Return to Interiors</button>
+                    <button id="securityMenuToggle" class="menu-toggle" data-menu-toggle="securityNav" data-menu-class="nav-open-security" aria-label="Open menu" aria-expanded="false" aria-controls="securityNav">
+                        <span></span><span></span><span></span>
+                    </button>
+                </div>
+            </header>
+            <nav id="securityNav">
+                <a href="#security-home" class="active">Overview</a>
+                <a href="#security-services">Services</a>
+                <a href="#security-method">Method</a>
+                <a href="#security-coverage">Coverage</a>
+                <a href="#security-intel">Intel</a>
+                <a href="#security-contact">Contact</a>
+            </nav>
+
+            <main class="onepage">
+                <section id="security-home" class="hero-jeton hero security-hero reveal fx-clip" style="position:relative;">
+                    <div class="bg-grid"></div>
+                    <div class="orb orb-1" data-parallax-y="0.05"></div>
+                    <div class="orb orb-2" data-parallax-y="0.09"></div>
+                    <div class="hero-inner fx-rise" data-parallax="0.12">
+                        <h1 class="grad-text">Outsmart loss before it happens.</h1>
+                        <p>Ømnilon Security trains covert Secret Lifters who behave like organized crews. We simulate theft, fraud, and policy abuse across every surface—physical or digital—so you can close the gaps with confidence.</p>
+                        <div class="cta-row">
+                            <a class="btn btn-jeton" href="#security-contact">Schedule an audit</a>
+                            <a class="btn btn-outline" href="#security-method">See the protocol</a>
+                        </div>
+                    </div>
+                    <div class="mock-window reveal from-right" aria-hidden="true">
+                        <img src="https://images.unsplash.com/photo-1529429617124-aee797f0e4c9?q=80&w=1600&auto=format&fit=crop" alt="Loss prevention dashboard" loading="lazy" />
+                    </div>
+                    <a class="scroll-cue" href="#security-services" aria-label="Scroll to security services"></a>
+                </section>
+
+                <section id="security-services" class="section feature-grid stagger features-jeton security-features" data-stagger-step="0.08">
+                    <article class="feature jeton-card fx-rise">
+                        <h3>In-Store Vulnerability Sweep</h3>
+                        <p>Secret Lifters map blind spots, ticket swaps, and exit paths using the same playbooks as professional boosters.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Policy & POS Penetration</h3>
+                        <p>Stress test returns, overrides, coupon stacking, and self-checkout flows to surface exploitable loopholes.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Loss Data & CCTV Sync</h3>
+                        <p>Correlate shrink data with floor observations and video to prioritize high-yield remediation.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Staff Readiness Drills</h3>
+                        <p>Run live “caught-in-the-act” simulations to coach compliant, high-empathy intervention tactics.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Ecommerce Exploit Hunt</h3>
+                        <p>Simulate bots, refund abuse, affiliate fraud, and skimming to harden digital storefronts.</p>
+                    </article>
+                    <article class="feature jeton-card fx-rise">
+                        <h3>Specialty & High-Risk Scenarios</h3>
+                        <p>Cannabis, luxury, BOPIS, and dark stores—we build custom threat models for niche operations.</p>
+                    </article>
+                </section>
+
+                <section id="security-method" class="section process reveal security-process">
+                    <h2>How Secret Lifters work</h2>
+                    <ol>
+                        <li>Align on threat personas, priority assets, and guardrails.</li>
+                        <li>Deploy trained operatives to run covert field and digital scenarios.</li>
+                        <li>Debrief leadership with raw footage, data trails, and staff observations.</li>
+                        <li>Deliver prioritized fixes, rapid wins, and long-term safeguards.</li>
+                    </ol>
+                </section>
+
+                <section id="security-coverage" class="section security-coverage fx-rise">
+                    <h2>Full-spectrum coverage</h2>
+                    <div class="coverage-grid">
+                        <div class="coverage-card">
+                            <h3>Physical</h3>
+                            <p>Merchandising, RFID, fitting rooms, exit routes, cash wraps, and back-of-house logistics audits.</p>
+                        </div>
+                        <div class="coverage-card">
+                            <h3>Digital</h3>
+                            <p>Cart flows, loyalty, payments, BOPIS, and OMS integrations tested for fraud and automation abuse.</p>
+                        </div>
+                        <div class="coverage-card">
+                            <h3>People</h3>
+                            <p>Associate readiness, vendor risk, third-party delivery, and policy compliance evaluations.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="security-intel" class="section security-intel reveal">
+                    <div class="intel-copy">
+                        <h2>Deliverables you can act on</h2>
+                        <p>Every engagement concludes with a prioritized briefing crafted for operators, finance, and security teams alike.</p>
+                        <ul class="intel-list">
+                            <li>Loss scenario scoring ranked by severity and probability.</li>
+                            <li>Video highlights and annotated transaction trails.</li>
+                            <li>Quick-win fixes with cost, effort, and expected shrink reduction.</li>
+                            <li>Long-term resilience roadmap with training recommendations.</li>
+                        </ul>
+                    </div>
+                    <div class="intel-metrics">
+                        <div class="metric-card">
+                            <span class="metric">48h</span>
+                            <p>to deliver your first remediation actions after fieldwork.</p>
+                        </div>
+                        <div class="metric-card">
+                            <span class="metric">30%</span>
+                            <p>average shrink exposure uncovered in initial sweeps.</p>
+                        </div>
+                        <div class="metric-card">
+                            <span class="metric">+6</span>
+                            <p>channels assessed—storefront, ecom, social commerce, BOPIS, last-mile, and vendor access.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="security-fieldnotes" class="section gallery-grid features-jeton security-fieldnotes">
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1517242022824-2f95c1c2b2ab?q=80&w=1600&auto=format&fit=crop" alt="Undercover operative observing a retail floor"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?q=80&w=1600&auto=format&fit=crop" alt="POS terminal detail during audit"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?q=80&w=1600&auto=format&fit=crop" alt="Security analyst reviewing camera feeds"></figure>
+                    <figure class="fx-rise"><img data-src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?q=80&w=1600&auto=format&fit=crop" alt="Warehouse aisle inspection"></figure>
+                </section>
+
+                <section class="section cta-stripe fx-rise security-cta">
+                    <h3>Ready to pressure test your defenses?</h3>
+                    <p>Secret Lifters operate discreetly, professionally, and with full documentation so you stay ahead of adversaries.</p>
+                    <div class="cta-row">
+                        <a class="btn btn-jeton" href="#security-contact">Book a briefing</a>
+                        <a class="btn btn-outline" href="#security-services">See our services</a>
+                    </div>
+                </section>
+
+                <section id="security-contact" class="section contact-form reveal security-contact">
+                    <h2>Book a Secret Lifter assessment</h2>
+                    <form id="securityContactForm" data-contact-form data-experience="security">
+                        <label for="securityName">Name:</label>
+                        <input type="text" id="securityName" name="name" required>
+                        <label for="securityEmail">Email:</label>
+                        <input type="email" id="securityEmail" name="email" required>
+                        <label for="securityAsset">Primary location or URL:</label>
+                        <input type="text" id="securityAsset" name="asset" placeholder="Store address, region, or ecommerce link">
+                        <label for="securityService">Engagement focus:</label>
+                        <select id="securityService" name="service">
+                            <option value="In-store vulnerability sweep">In-store vulnerability sweep</option>
+                            <option value="Policy and POS penetration">Policy and POS penetration</option>
+                            <option value="Ecommerce exploit hunt">Ecommerce exploit hunt</option>
+                            <option value="Staff readiness drill">Staff readiness drill</option>
+                            <option value="Comprehensive program">Comprehensive program</option>
+                        </select>
+                        <label for="securityScale">Portfolio scale:</label>
+                        <select id="securityScale" name="budget">
+                            <option value="Single site">Single site</option>
+                            <option value="2-10 locations">2-10 locations</option>
+                            <option value="11-50 locations">11-50 locations</option>
+                            <option value="National network">National network</option>
+                        </select>
+                        <label for="securityMessage">What should we know?</label>
+                        <textarea id="securityMessage" name="message" placeholder="Share loss pain points, known scams, or upcoming initiatives." required></textarea>
+                        <button type="submit" class="btn btn-jeton">Submit</button>
+                    </form>
+                    <p class="form-status" data-form-status aria-live="polite" role="status"></p>
+                    <ul class="contact-meta">
+                        <li>Security desk: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
+                        <li>Direct line: <a href="tel:4049198026">404-919-8026</a></li>
+                        <li>Rapid response: 7 days, 6am–10pm ET for active investigations.</li>
+                    </ul>
+                </section>
+            </main>
+        </div>
+        <footer class="site-footer">
+            <p>&copy; 2025 Ømnilon Security — Asset Protection Intelligence</p>
+        </footer>
+    </div>
+
     <script src="script.js"></script>
     <script src="contact.js"></script>
 </body>
 </html>
-
-
-
-
-
-
-

--- a/script.js
+++ b/script.js
@@ -114,15 +114,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
-// Simple parallax for hero text
+// Simple parallax for hero text (supports multiple heroes)
 (() => {
-    const heroInner = document.querySelector('.hero .hero-inner[data-parallax]');
-    if (!heroInner) return;
-    const speed = parseFloat(heroInner.getAttribute('data-parallax')) || 0.1;
+    const heroInners = Array.from(document.querySelectorAll('.hero .hero-inner[data-parallax]'));
+    if (!heroInners.length) return;
     const onScroll = () => {
-        const rect = heroInner.getBoundingClientRect();
-        const offset = Math.min(40, Math.max(-40, (window.innerHeight - rect.top) * speed * 0.1));
-        heroInner.style.transform = `translateY(${offset}px)`;
+        heroInners.forEach((heroInner) => {
+            const speed = parseFloat(heroInner.getAttribute('data-parallax')) || 0.1;
+            const rect = heroInner.getBoundingClientRect();
+            const offset = Math.min(40, Math.max(-40, (window.innerHeight - rect.top) * speed * 0.1));
+            heroInner.style.transform = `translateY(${offset}px)`;
+        });
     };
     window.addEventListener('scroll', onScroll, { passive: true });
     onScroll();
@@ -159,7 +161,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // Micro-interactions for buttons: subtle spring on hover/press
 document.addEventListener('DOMContentLoaded', () => {
     const press = (el, scale) => { el.style.transform = `scale(${scale})`; };
-    document.querySelectorAll('.btn, nav a').forEach(el => {
+document.querySelectorAll('.btn, nav a, .experience-pill, .selector-card').forEach(el => {
         el.style.transition = 'transform .18s cubic-bezier(.2,.8,.2,1.4), box-shadow .18s';
         el.addEventListener('mouseenter', () => press(el, 1.03));
         el.addEventListener('mouseleave', () => press(el, 1));
@@ -388,13 +390,108 @@ document.addEventListener('DOMContentLoaded', () => {
     ensureSectionReady(location.hash);
 });
 
-// Mobile menu toggle
-(function(){
-  const btn = document.getElementById('menuToggle');
-  if(!btn) return;
-  btn.addEventListener('click', ()=>{
-    const open = !document.body.classList.contains('nav-open');
-    document.body.classList.toggle('nav-open', open);
-    btn.setAttribute('aria-expanded', String(open));
-  });
-})();
+// Experience selector + multi-nav toggle handling
+document.addEventListener('DOMContentLoaded', () => {
+    const selector = document.getElementById('experienceSelector');
+    const experiences = {
+        interiors: document.getElementById('interiorsExperience'),
+        security: document.getElementById('securityExperience')
+    };
+    const toggles = Array.from(document.querySelectorAll('[data-menu-toggle]'));
+
+    const closeNavs = () => {
+        ['nav-open', 'nav-open-security'].forEach(cls => document.body.classList.remove(cls));
+        toggles.forEach(btn => btn.setAttribute('aria-expanded', 'false'));
+    };
+
+    toggles.forEach(btn => {
+        const targetId = btn.getAttribute('data-menu-toggle');
+        const bodyClass = btn.getAttribute('data-menu-class') || 'nav-open';
+        const nav = targetId ? document.getElementById(targetId) : null;
+        if (!nav) return;
+        btn.addEventListener('click', () => {
+            const willOpen = !document.body.classList.contains(bodyClass);
+            closeNavs();
+            document.body.classList.toggle(bodyClass, willOpen);
+            btn.setAttribute('aria-expanded', String(willOpen));
+        });
+        nav.querySelectorAll('a[href^="#"]').forEach(link => {
+            link.addEventListener('click', () => {
+                document.body.classList.remove(bodyClass);
+                btn.setAttribute('aria-expanded', 'false');
+            });
+        });
+    });
+
+    const setExperienceVisibility = (name) => {
+        Object.entries(experiences).forEach(([key, wrapper]) => {
+            if (!wrapper) return;
+            const active = key === name;
+            wrapper.hidden = !active;
+            wrapper.setAttribute('aria-hidden', String(!active));
+        });
+    };
+
+    const activateExperience = (name) => {
+        if (!experiences[name]) return;
+        setExperienceVisibility(name);
+        document.body.classList.add('experience-active');
+        document.body.classList.remove('experience-interiors', 'experience-security');
+        document.body.classList.add(name === 'security' ? 'experience-security' : 'experience-interiors');
+        document.body.dataset.experience = name;
+        document.querySelectorAll('nav a').forEach(link => link.classList.remove('active'));
+        const navEl = document.getElementById(name === 'security' ? 'securityNav' : 'siteNav');
+        const firstLink = navEl ? navEl.querySelector('a[href^="#"]') : null;
+        if (firstLink) firstLink.classList.add('active');
+        closeNavs();
+        if (selector && !selector.classList.contains('is-dismissed')) {
+            selector.classList.add('is-dismissed');
+            selector.setAttribute('aria-hidden', 'true');
+            setTimeout(() => { selector.hidden = true; }, 450);
+        }
+        window.scrollTo(0, 0);
+    };
+
+    if (selector) {
+        selector.querySelectorAll('[data-target]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const target = btn.getAttribute('data-target');
+                if (!target) return;
+                activateExperience(target);
+            });
+        });
+    }
+
+    document.querySelectorAll('[data-switch-experience]').forEach(btn => {
+        btn.addEventListener('click', (event) => {
+            event.preventDefault();
+            const target = btn.getAttribute('data-switch-experience');
+            if (!target) return;
+            activateExperience(target);
+        });
+    });
+
+    const params = new URLSearchParams(window.location.search);
+    const requested = params.get('experience');
+    const hash = window.location.hash || '';
+    let initial = null;
+    if (requested && experiences[requested]) {
+        initial = requested;
+    } else if (/^#security-/.test(hash)) {
+        initial = 'security';
+    } else if (/^#(home|services|portfolio|about|contact)/i.test(hash)) {
+        initial = 'interiors';
+    }
+
+    if (initial) {
+        activateExperience(initial);
+        if (hash) {
+            const target = document.querySelector(hash);
+            if (target) {
+                requestAnimationFrame(() => {
+                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                });
+            }
+        }
+    }
+});

--- a/style.css
+++ b/style.css
@@ -599,7 +599,201 @@ body {
     color: var(--dark-color);
 }
 
-.brand-header { padding: 28px 0 16px; }
+.experience-selector {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: clamp(24px, 5vw, 60px);
+    background: radial-gradient(1200px 700px at -10% -20%, rgba(255, 181, 71, 0.2), transparent 65%),
+        radial-gradient(900px 600px at 110% 10%, rgba(82, 196, 211, 0.18), transparent 60%),
+        linear-gradient(180deg, rgba(11, 13, 18, 0.96), rgba(11, 13, 18, 0.88));
+    z-index: 4000;
+    color: #f0f4f2;
+    transition: opacity .45s ease, visibility .45s ease;
+}
+
+.experience-selector.is-dismissed {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.selector-inner {
+    max-width: min(960px, 92vw);
+    text-align: center;
+    background: rgba(13, 16, 22, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 28px;
+    padding: clamp(28px, 6vw, 60px);
+    box-shadow: 0 30px 90px rgba(0, 0, 0, 0.45);
+}
+
+.selector-badge {
+    display: inline-flex;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(255, 181, 71, 0.14);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    letter-spacing: 0.3em;
+    font-size: 11px;
+    text-transform: uppercase;
+    margin-bottom: 16px;
+}
+
+.selector-copy {
+    margin: 16px auto 32px;
+    max-width: 640px;
+    color: #cbd4d0;
+}
+
+.selector-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(16px, 3vw, 26px);
+    margin-top: clamp(18px, 3vw, 36px);
+}
+
+.selector-card {
+    position: relative;
+    border-radius: 20px;
+    padding: clamp(22px, 3vw, 32px);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    transition: transform .35s cubic-bezier(.2,.65,.2,1), box-shadow .35s ease, border-color .35s ease;
+}
+
+.selector-card::after {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    opacity: 0;
+    transition: opacity .35s ease;
+}
+
+.selector-card:focus-visible,
+.selector-card:hover {
+    transform: translateY(-4px) scale(1.01);
+    box-shadow: 0 22px 60px rgba(11, 13, 18, 0.6);
+    border-color: rgba(255, 181, 71, 0.4);
+}
+
+.selector-card:focus-visible::after,
+.selector-card:hover::after {
+    opacity: 1;
+}
+
+.selector-heading {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(20px, 2.1vw, 26px);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.selector-text {
+    font-size: 15px;
+    line-height: 1.6;
+    color: #d7dfdd;
+}
+
+.selector-cta {
+    font-weight: 600;
+    font-size: 14px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #ffb547;
+}
+
+.noscript-warning {
+    text-align: center;
+    padding: 12px;
+    background: #ffefef;
+    color: #611b1b;
+    font-size: 14px;
+}
+
+.experience {
+    min-height: 100vh;
+    position: relative;
+}
+
+.experience[hidden] {
+    display: none !important;
+}
+
+.header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.experience-pill {
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.04);
+    color: #f4f7f6;
+    border-radius: 999px;
+    padding: 8px 16px;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background .25s ease, border-color .25s ease, color .25s ease;
+}
+
+.experience-pill:hover,
+.experience-pill:focus-visible {
+    background: rgba(255, 181, 71, 0.16);
+    border-color: rgba(255, 181, 71, 0.4);
+    color: #fff1d6;
+}
+
+.contact-meta {
+    list-style: none;
+    margin-top: 12px;
+    padding-left: 0;
+    color: #b9c4c4;
+}
+
+.contact-meta li + li {
+    margin-top: 6px;
+}
+
+.contact-meta a {
+    color: inherit;
+    text-decoration: underline;
+}
+
+body.experience-interiors .experience-pill[data-switch-experience="security"] {
+    background: rgba(255, 255, 255, 0.02);
+}
+
+body.experience-security .experience-pill[data-switch-experience="interiors"] {
+    background: rgba(82, 196, 211, 0.14);
+    border-color: rgba(82, 196, 211, 0.36);
+    color: #dff7ff;
+}
+
+body.experience-security #scrollProgress {
+    background: linear-gradient(90deg, #38f9d7, #17c6ff);
+    box-shadow: 0 0 10px rgba(23, 198, 255, 0.4);
+}
+
+.brand-header {
+    padding: 28px 0 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+}
 .brand { display: inline-flex; align-items: baseline; gap: 6px; text-decoration: none; color: var(--dark-color); }
 .brand-mark { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 34px; color: var(--primary-color); line-height: 1; }
 .brand-name { font-weight: 600; font-size: 22px; letter-spacing: 0.08em; text-transform: uppercase; }
@@ -684,6 +878,66 @@ body {
 .theme-jeton nav { background-color: rgba(16, 20, 26, 0.85); backdrop-filter: blur(10px) saturate(140%); -webkit-backdrop-filter: blur(10px) saturate(140%); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,.35); }
 .theme-jeton nav a { color: #e8ecec; border-radius: 999px; }
 .theme-jeton nav a:hover, .theme-jeton nav a.active { background: linear-gradient(90deg, #ff7a18, #ffb547); color: #0e1117; }
+
+#securityExperience nav { background-color: rgba(7, 14, 18, 0.9); border: 1px solid rgba(56, 249, 215, 0.18); box-shadow: 0 18px 48px rgba(5, 11, 15, 0.45); }
+#securityExperience nav a { color: #e4f9ff; }
+#securityExperience nav a:hover,
+#securityExperience nav a.active { background: linear-gradient(90deg, #22ffd7, #17c6ff); color: #05121a; }
+
+#securityExperience .brand { color: #dff7ff; }
+#securityExperience .brand-title { background: linear-gradient(90deg, #22ffd7, #a6f4ff); -webkit-background-clip: text; background-clip: text; color: transparent; }
+
+#securityExperience .grad-text { background: linear-gradient(92deg, #e5feff 0%, #9ef7ff 42%, #22ffd7 92%); -webkit-background-clip: text; background-clip: text; color: transparent; }
+
+.security-hero .orb-1 { background: radial-gradient(circle at 30% 30%, rgba(34, 255, 215, 0.4), transparent 65%); }
+.security-hero .orb-2 { background: radial-gradient(circle at 60% 40%, rgba(23, 198, 255, 0.32), transparent 60%); }
+
+#securityExperience .btn.btn-jeton { color: #03141d; background: linear-gradient(90deg, #22ffd7, #17c6ff); box-shadow: 0 8px 28px rgba(23, 198, 255, 0.28); }
+#securityExperience .btn.btn-outline { border: 1px solid rgba(118, 214, 228, 0.4); color: #dff7ff; }
+
+.security-features .jeton-card { background: rgba(8, 14, 18, 0.9); border: 1px solid rgba(34, 255, 215, 0.18); box-shadow: 0 16px 46px rgba(3, 10, 14, 0.45); }
+.security-features .jeton-card h3 { color: #e5feff; }
+.security-features .jeton-card p { color: #b9d9dc; }
+
+.security-process { max-width: 900px; }
+.security-process h2 { color: #e5feff; }
+.security-process ol { color: #b7d5d9; }
+.security-process li { margin-bottom: 8px; }
+
+.security-coverage { text-align: center; }
+.coverage-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 18px; margin-top: 20px; }
+.coverage-card { background: rgba(8, 14, 18, 0.9); border: 1px solid rgba(56, 249, 215, 0.16); border-radius: 18px; padding: 22px; box-shadow: 0 16px 44px rgba(3, 10, 14, 0.4); text-align: left; }
+.coverage-card h3 { font-family: 'Playfair Display', serif; margin-bottom: 8px; color: #e5feff; letter-spacing: 0.06em; }
+.coverage-card p { color: #b7d5d9; line-height: 1.6; }
+
+.security-intel { display: grid; grid-template-columns: minmax(280px, 1.1fr) minmax(220px, 1fr); gap: clamp(20px, 4vw, 36px); align-items: stretch; }
+.security-intel h2 { color: #e5feff; }
+.security-intel p { color: #b9d9dc; }
+.intel-list { list-style: none; padding-left: 0; margin-top: 18px; display: grid; gap: 10px; color: #c5e4e8; }
+.intel-list li { position: relative; padding-left: 28px; }
+.intel-list li::before { content: ""; position: absolute; left: 0; top: 8px; width: 14px; height: 14px; border-radius: 50%; background: linear-gradient(135deg, #22ffd7, #17c6ff); box-shadow: 0 0 0 3px rgba(34, 255, 215, 0.18); }
+
+.intel-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 16px; }
+.metric-card { background: radial-gradient(140% 120% at 20% -10%, rgba(34, 255, 215, 0.25), rgba(8, 14, 18, 0.92)); border: 1px solid rgba(34, 255, 215, 0.2); border-radius: 18px; padding: 20px; text-align: left; display: flex; flex-direction: column; gap: 6px; }
+.metric-card p { color: #c5e4e8; font-size: 14px; line-height: 1.5; }
+.metric { font-size: 36px; font-weight: 700; font-family: 'Playfair Display', serif; color: #22ffd7; letter-spacing: 0.08em; }
+
+.security-fieldnotes figure { background: rgba(8, 14, 18, 0.9); border: 1px solid rgba(23, 198, 255, 0.18); }
+
+.security-cta { background: linear-gradient(180deg, rgba(34, 255, 215, 0.12), rgba(23, 198, 255, 0.08)); border: 1px solid rgba(23, 198, 255, 0.22); box-shadow: 0 18px 50px rgba(3, 10, 14, 0.45); }
+.security-cta p { color: #c5e4e8; }
+
+#securityExperience .contact-form { background: rgba(8, 14, 18, 0.88); border: 1px solid rgba(34, 255, 215, 0.18); box-shadow: 0 16px 44px rgba(3, 10, 14, 0.45); }
+#securityExperience .contact-form h2 { color: #e5feff; }
+#securityExperience .contact-form label { color: #d7eff1; }
+#securityExperience .contact-form input,
+#securityExperience .contact-form select,
+#securityExperience .contact-form textarea { background: rgba(6, 12, 18, 0.92); border: 1px solid rgba(82, 196, 211, 0.32); color: #e8f8fa; }
+#securityExperience .contact-form input:focus,
+#securityExperience .contact-form select:focus,
+#securityExperience .contact-form textarea:focus { border-color: #22ffd7; box-shadow: 0 0 0 2px rgba(34, 255, 215, 0.22); }
+#securityExperience .contact-form button { background: linear-gradient(90deg, #22ffd7, #17c6ff); color: #03141d; }
+#securityExperience .contact-meta { color: #96dce4; }
 
 .grad-text{ background: linear-gradient(92deg,#ffffff 0%, #e1f0e7 35%, #ffb547 80%); -webkit-background-clip:text; background-clip:text; color:transparent; }
 
@@ -785,10 +1039,13 @@ body {
 /* Mobile menu */
 .menu-toggle{ display:none; margin-left:auto; background:transparent; border:none; cursor:pointer; }
 .menu-toggle span{ display:block; width:24px; height:2px; background:#e8ecec; margin:5px 0; border-radius:2px; transition:transform .2s, opacity .2s; }
+body.experience-security .menu-toggle span{ background:#9fe8f5; }
 @media (max-width: 820px){
   .menu-toggle{ display:block; }
   #siteNav{ position: fixed; top:70px; left:50%; transform:translateX(-50%); width: min(92vw, 680px); background: rgba(16,20,26,.95); border:1px solid rgba(255,255,255,.08); border-radius:14px; padding:10px; display:none; flex-wrap:wrap; gap:8px; justify-content:center; z-index:1200; }
   body.nav-open #siteNav{ display:flex; }
+  #securityNav{ position: fixed; top:70px; left:50%; transform:translateX(-50%); width:min(92vw, 680px); background: rgba(7,14,18,.95); border:1px solid rgba(34,255,215,.22); border-radius:14px; padding:10px; display:none; flex-wrap:wrap; gap:8px; justify-content:center; z-index:1200; }
+  body.nav-open-security #securityNav{ display:flex; }
 }
 
 /* Principles */


### PR DESCRIPTION
## Summary
- add an experience selector overlay that lets visitors choose between Ømnilon Interiors and the new Security division
- preserve the original interiors one-pager while introducing a full Ømnilon Security journey with tailored sections and contact funnel
- refresh shared styling and scripts to support multiple experiences, dual navigation, and multi-form handling

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cee3a390a08321ba4fb576f2039b37