### PR TITLE
Improve mobile navigation and layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -604,6 +604,7 @@ body {
     inset: 0;
     display: grid;
     place-items: center;
+    align-content: center;
     padding: clamp(24px, 5vw, 60px);
     background: radial-gradient(1200px 700px at -10% -20%, rgba(255, 181, 71, 0.2), transparent 65%),
         radial-gradient(900px 600px at 110% 10%, rgba(82, 196, 211, 0.18), transparent 60%),
@@ -611,6 +612,8 @@ body {
     z-index: 4000;
     color: #f0f4f2;
     transition: opacity .45s ease, visibility .45s ease;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 .experience-selector.is-dismissed {
@@ -689,6 +692,23 @@ body {
 .selector-card:focus-visible::after,
 .selector-card:hover::after {
     opacity: 1;
+}
+
+@media (max-height: 760px) {
+    .experience-selector {
+        align-content: start;
+    }
+
+    .selector-inner {
+        margin-top: clamp(24px, 8vh, 48px);
+        margin-bottom: clamp(24px, 8vh, 48px);
+    }
+}
+
+@media (max-width: 520px) {
+    .selector-inner {
+        padding: clamp(22px, 7vw, 32px);
+    }
 }
 
 .selector-heading {
@@ -913,6 +933,12 @@ body.experience-security #scrollProgress {
 .security-intel { display: grid; grid-template-columns: minmax(280px, 1.1fr) minmax(220px, 1fr); gap: clamp(20px, 4vw, 36px); align-items: stretch; }
 .security-intel h2 { color: #e5feff; }
 .security-intel p { color: #b9d9dc; }
+.security-intel > * { min-width: 0; }
+.security-intel .intel-metrics { align-self: stretch; }
+
+@media (max-width: 880px) {
+    .security-intel { grid-template-columns: 1fr; }
+}
 .intel-list { list-style: none; padding-left: 0; margin-top: 18px; display: grid; gap: 10px; color: #c5e4e8; }
 .intel-list li { position: relative; padding-left: 28px; }
 .intel-list li::before { content: ""; position: absolute; left: 0; top: 8px; width: 14px; height: 14px; border-radius: 50%; background: linear-gradient(135deg, #22ffd7, #17c6ff); box-shadow: 0 0 0 3px rgba(34, 255, 215, 0.18); }
@@ -970,6 +996,11 @@ body.experience-security #scrollProgress {
 .section { scroll-snap-align: start; scroll-margin-top: clamp(110px, 16vw, 190px); }
 .section-leave { opacity: 0.6; transform: scale(.995); filter: blur(1px); transition: opacity .35s ease, transform .35s ease, filter .35s ease; }
 .onepage .section { padding-top: 24px; padding-bottom: 24px; content-visibility: auto; contain-intrinsic-size: 1px 900px; }
+
+@media (max-width: 768px) {
+    .onepage { scroll-snap-type: none; }
+    .section { scroll-snap-align: none; scroll-margin-top: 88px; }
+}
 
 /* Scroll progress bar */
 #scrollProgress{ position:fixed; top:0; left:0; height:3px; width:0; background:linear-gradient(90deg,#ff7a18,#ffb547); z-index:3000; box-shadow:0 0 8px rgba(255,122,24,.5); }


### PR DESCRIPTION
## Summary
- allow the experience selector overlay to scroll on short mobile viewports and trim padding on small screens
- stack the security intel grid vertically on narrow displays to avoid clipped content
- disable section scroll snapping on phones for smoother navigation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2c22aab388321ab5d60b6570ead85