### PR TITLE
Add Stripe buy button to payment page

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -67,6 +67,18 @@
         <div class="feature-grid features-jeton" id="serviceDetails"></div>
         <h2 class="payments-subhead">Make a payment</h2>
         <div class="feature-grid features-jeton" id="paymentForms">
+          <article class="feature jeton-card stripe-button-card">
+            <h3>Pay Now</h3>
+            <p>Use our secure Stripe checkout to submit the standard payment or deposit instantly.</p>
+            <stripe-buy-button
+              buy-button-id="buy_btn_1SByhQ2dSpsiXnOLd7LObOHQ"
+              publishable-key="pk_live_51S7wAs2dSpsiXnOLBxKLtF0iAkgXgMr7QMn0TAo9fDIbiJXbfCOwyNzMErUJ5OcIUWityN0FaXjjRh2KyxRBFNNo00RheMkkDi"
+            >
+            </stripe-buy-button>
+            <p class="mini">
+              Having trouble loading the button? <a href="https://buy.stripe.com/4gM6oA6sH9S59ao3NgbEA01" target="_blank" rel="noopener">Open the payment page in a new tab</a>.
+            </p>
+          </article>
           <article class="feature jeton-card">
             <h3>Pay Deposit</h3>
             <p>Enter your name, email, and amount. We’ll confirm and send a receipt.</p>
@@ -223,5 +235,6 @@
   }
   renderServices();
   </script>
+  <script async src="https://js.stripe.com/v3/buy-button.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed the provided Stripe Buy Button on the interiors payment page for immediate checkout access
- supply a direct payment-link fallback so visitors can open the Stripe checkout manually
- load Stripe's buy-button.js to initialize the embedded button

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d7ef1d46b083219f78f28d2dd41ddd