### PR TITLE
Fix payment page visibility

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -123,6 +123,7 @@
     <p>&copy; 2025 Ømnilon Interiors — Atlanta, GA</p>
   </footer>
 
+  <script defer src="script.js"></script>
   <script>
   const STRIPE_PK = 'pk_test_51S7wB6GvDJqd2Z6nuk9Hv4Kc18ashF3CW2vpE7lPxuxxsO9o89G8w9vwOJasmtH36Pif5FqqXQnknOZTYQoDxLXD00vMMW006q';
   const stripe = Stripe(STRIPE_PK);

--- a/style.css
+++ b/style.css
@@ -1006,10 +1006,12 @@ body.experience-security #scrollProgress {
 #scrollProgress{ position:fixed; top:0; left:0; height:3px; width:0; background:linear-gradient(90deg,#ff7a18,#ffb547); z-index:3000; box-shadow:0 0 8px rgba(255,122,24,.5); }
 
 /* Fluid scroll animations */
-.fx-rise{ opacity:0; transform: translateY(28px) scale(.985); filter: blur(2px); transition: opacity .7s cubic-bezier(.2,.65,.2,1), transform .7s cubic-bezier(.2,.65,.2,1), filter .6s; }
-.fx-rise.is-inview{ opacity:1; transform:none; filter:blur(0); }
-.fx-clip{ opacity:0; clip-path: inset(12% 10% 12% 10% round 16px); filter: blur(6px); transition: opacity .8s cubic-bezier(.2,.65,.2,1), clip-path .9s cubic-bezier(.2,.65,.2,1), filter .9s; }
-.fx-clip.is-inview{ opacity:1; clip-path: inset(0 0 0 0); filter: blur(0); }
+.fx-rise{ transition: opacity .7s cubic-bezier(.2,.65,.2,1), transform .7s cubic-bezier(.2,.65,.2,1), filter .6s; }
+.reveal.fx-rise{ opacity:0; transform: translateY(28px) scale(.985); filter: blur(2px); }
+.reveal.fx-rise.is-visible{ opacity:1; transform:none; filter:blur(0); }
+.fx-clip{ transition: opacity .8s cubic-bezier(.2,.65,.2,1), clip-path .9s cubic-bezier(.2,.65,.2,1), filter .9s; }
+.reveal.fx-clip{ opacity:0; clip-path: inset(12% 10% 12% 10% round 16px); filter: blur(6px); }
+.reveal.fx-clip.is-visible{ opacity:1; clip-path: inset(0 0 0 0); filter: blur(0); }
 
 /* Hero video */
 .hero-video{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; border-radius:16px; opacity:0; transition:opacity .6s ease; }


### PR DESCRIPTION
## Summary
- load the shared animation script on the payment page so reveal elements activate
- adjust fx-rise/fx-clip styles so only reveal-tagged content is hidden before animation, preventing cards from staying invisible

## Testing
- Manual verification in local browser

------
https://chatgpt.com/codex/tasks/task_e_68d7f31cad208321989ed8aee89f31e3