### PR TITLE
Refine payment experience and add project brief intake

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -28,94 +28,102 @@
       <section class="hero-jeton hero reveal fx-clip" style="position:relative;">
         <div class="bg-grid"></div>
         <div class="hero-inner fx-rise">
-          <h1 class="grad-text">Secure Payments</h1>
-          <p>Pay deposits and invoices safely. If you need a custom payment link, request one below.</p>
+          <h1 class="grad-text">Book &amp; Pay</h1>
+          <p>Reserve your project with a 50% deposit and wrap up future invoices securely.</p>
         </div>
       </section>
 
       <section class="section payments fx-rise">
-        <div class="service-tiles" id="serviceSpotlight">
-          <article class="service-card fx-rise">
-            <img src="https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?q=80&w=1400&auto=format&fit=crop" alt="Digital moodboard on a tablet" loading="lazy" />
-            <div class="service-card__overlay">
-              <h3>E‑Design (Virtual)</h3>
-              <p>A fast, mood‑board‑to‑makeover plan you can execute on your timeline—layout, palette, shoppable list, and a step‑by‑step setup guide.</p>
-            </div>
-          </article>
-          <article class="service-card fx-rise">
-            <img src="https://images.unsplash.com/photo-1519710164239-da123dc03ef4?q=80&w=1400&auto=format&fit=crop" alt="Tailored living room" loading="lazy" />
-            <div class="service-card__overlay">
-              <h3>Residential Room Refresh</h3>
-              <p>A precision tune‑up for one room—new paint and lighting, scaled furniture, curated textiles, and styling that makes what you already own feel intentional.</p>
-            </div>
-          </article>
-          <article class="service-card fx-rise">
-            <img src="https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1400&auto=format&fit=crop" alt="Staged dining area" loading="lazy" />
-            <div class="service-card__overlay">
-              <h3>Home Staging</h3>
-              <p>Market‑ready rooms styled to photograph beautifully and show even better—edited furniture, art, and accents that spotlight light, space, and flow.</p>
-            </div>
-          </article>
-          <article class="service-card fx-rise">
-            <img src="https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?q=80&w=1400&auto=format&fit=crop" alt="Boutique coffee shop interior" loading="lazy" />
-            <div class="service-card__overlay">
-              <h3>Small Commercial / Boutique</h3>
-              <p>Brand‑minded interiors for salons, cafés, and studios—optimized floor plans, durable finishes, and ‘stop‑and‑shoot’ moments that convert foot traffic.</p>
-            </div>
-          </article>
+        <div class="payment-overview jeton-card">
+          <h2>How booking works</h2>
+          <p>
+            To lock in design time on our calendar we require a <strong>50% deposit</strong> based on the proposal you
+            received. The remaining balance is due closer to install or final delivery.
+          </p>
+          <ul class="payment-checklist">
+            <li><span>50% deposit</span>Reserves your project start date and design window.</li>
+            <li><span>Remaining balance</span>Settled once sourcing, styling, or install is complete.</li>
+            <li><span>Flexible payment links</span>Request a custom Stripe link for larger invoices or retainers.</li>
+          </ul>
+          <div class="payment-alert" role="note">
+            <strong>Need a refresher?</strong> After you submit the deposit you’ll be directed to our
+            <a href="project-brief.html">project brief</a> to share goals, inspo, and room photos.
+          </div>
         </div>
-        <div class="feature-grid features-jeton" id="serviceDetails"></div>
-        <h2 class="payments-subhead">Make a payment</h2>
-        <div class="feature-grid features-jeton" id="paymentForms">
-          <article class="feature jeton-card stripe-button-card">
-            <h3>Pay Now</h3>
-            <p>Use our secure Stripe checkout to submit the standard payment or deposit instantly.</p>
+
+        <div class="payment-grid">
+          <article class="jeton-card payment-card">
+            <h3>Pay the 50% deposit</h3>
+            <p>Use the amount shown on your proposal (half of the total project fee).</p>
+            <form class="pay-form" id="depositForm">
+              <label for="dep_name">Name</label>
+              <input type="text" id="dep_name" required />
+              <label for="dep_email">Email</label>
+              <input type="email" id="dep_email" required />
+              <label for="dep_amount">Deposit amount (USD)</label>
+              <input type="number" min="1" step="0.01" id="dep_amount" required />
+              <p class="mini">We will email a receipt as soon as the deposit clears.</p>
+              <button class="btn btn-jeton" type="submit">Submit deposit</button>
+              <p class="mini payment-status" id="dep_status" aria-live="polite"></p>
+            </form>
+          </article>
+
+          <article class="jeton-card payment-card">
+            <h3>Pay a custom invoice</h3>
+            <p>Need to split payments or settle a specific invoice? Share the details below.</p>
+            <form class="pay-form" id="invoiceForm">
+              <label for="inv_no">Invoice number</label>
+              <input type="text" id="inv_no" required />
+              <label for="inv_email">Email</label>
+              <input type="email" id="inv_email" required />
+              <label for="inv_amount">Amount (USD)</label>
+              <input type="number" min="1" step="0.01" id="inv_amount" required />
+              <p class="mini">We’ll respond with a secure Stripe checkout link within one business day.</p>
+              <button class="btn btn-jeton" type="submit">Request payment link</button>
+              <p class="mini payment-status" id="inv_status" aria-live="polite"></p>
+            </form>
+          </article>
+
+          <article class="jeton-card payment-card">
+            <h3>Quick pay portal</h3>
+            <p>Prefer to handle it yourself? Use our ready-to-go Stripe checkout link.</p>
             <stripe-buy-button
               buy-button-id="buy_btn_1SByhQ2dSpsiXnOLd7LObOHQ"
               publishable-key="pk_live_51S7wAs2dSpsiXnOLBxKLtF0iAkgXgMr7QMn0TAo9fDIbiJXbfCOwyNzMErUJ5OcIUWityN0FaXjjRh2KyxRBFNNo00RheMkkDi"
             >
             </stripe-buy-button>
             <p class="mini">
-              Having trouble loading the button? <a href="https://buy.stripe.com/4gM6oA6sH9S59ao3NgbEA01" target="_blank" rel="noopener">Open the payment page in a new tab</a>.
+              If the button doesn’t load, <a data-fallback-link target="_blank" rel="noopener">open the secure Stripe portal</a>.
             </p>
           </article>
-          <article class="feature jeton-card">
-            <h3>Pay Deposit</h3>
-            <p>Enter your name, email, and amount. We’ll confirm and send a receipt.</p>
-            <form class="pay-form" id="depositForm">
-              <label for="dep_name">Name</label>
-              <input type="text" id="dep_name" required />
-              <label for="dep_email">Email</label>
-              <input type="email" id="dep_email" required />
-              <label for="dep_amount">Amount (USD)</label>
-              <input type="number" min="1" step="0.01" id="dep_amount" required />
-              <button class="btn btn-jeton" type="submit">Pay Deposit</button>
-              <p class="mini" id="dep_status" aria-live="polite"></p>
-            </form>
-          </article>
-          <article class="feature jeton-card">
-            <h3>Pay Invoice</h3>
-            <p>Have an invoice? Share the number and amount and we’ll respond with a secure link.</p>
-            <form class="pay-form" id="invoiceForm">
-              <label for="inv_no">Invoice #</label>
-              <input type="text" id="inv_no" required />
-              <label for="inv_email">Email</label>
-              <input type="email" id="inv_email" required />
-              <label for="inv_amount">Amount (USD)</label>
-              <input type="number" min="1" step="0.01" id="inv_amount" required />
-              <button class="btn btn-jeton" type="submit">Pay Invoice</button>
-              <p class="mini" id="inv_status" aria-live="polite"></p>
-            </form>
-          </article>
-          <article class="feature jeton-card">
-            <h3>Need help?</h3>
-            <p>Unsure what to pay? Send a note and we’ll reply within one business day.</p>
-            <a class="btn btn-outline" href="index.html#contact">Contact us</a>
-          </article>
         </div>
-        <h2 class="payments-subhead">Popular add‑ons</h2>
-        <div class="feature-grid features-jeton" id="addonServices"></div>
-        <p class="mini" id="serviceStatus" aria-live="polite"></p>
+
+        <div class="payment-support-grid">
+          <article class="jeton-card support-card">
+            <h3>Next step: project brief</h3>
+            <p>
+              Once the deposit is complete, share your goals, floor plan notes, and room photos so our team can start concepting.
+            </p>
+            <a class="btn btn-outline" href="project-brief.html">Fill out the project brief</a>
+            <p class="mini">You can return to the brief anytime to update or add details.</p>
+          </article>
+
+          <article class="jeton-card support-card">
+            <h3>Need a hand?</h3>
+            <p>Unsure what amount to enter or need a different payment schedule? Let us know.</p>
+            <a class="btn btn-outline" href="index.html#contact">Message the studio</a>
+          </article>
+
+          <details class="jeton-card support-card service-summary" id="serviceSummaryCard">
+            <summary>See what each service includes</summary>
+            <div class="service-summary__inner">
+              <ul class="service-summary-list" id="serviceSummaryList"></ul>
+              <h4>Popular add-ons</h4>
+              <ul class="service-summary-list" id="addonSummaryList"></ul>
+              <p class="mini" id="serviceStatus" aria-live="polite"></p>
+            </div>
+          </details>
+        </div>
       </section>
     </main>
   </div>
@@ -128,112 +136,162 @@
   const STRIPE_PK = 'pk_test_51S7wB6GvDJqd2Z6nuk9Hv4Kc18ashF3CW2vpE7lPxuxxsO9o89G8w9vwOJasmtH36Pif5FqqXQnknOZTYQoDxLXD00vMMW006q';
   const stripe = Stripe(STRIPE_PK);
   const PAYMENT_LINK = 'https://buy.stripe.com/4gM6oA6sH9S59ao3NgbEA01';
-
-  async function createCheckout(name, amount, email, metadata={}){
-    const res = await fetch('/api/checkout', {
-      method:'POST', headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ name, amount, email, metadata })
-    });
-    const data = await res.json();
-    if(res.ok && data.id){
-      await stripe.redirectToCheckout({ sessionId: data.id });
-    } else if (data.url){
-      window.location = data.url;
-    } else {
-      throw new Error(data.message || 'Checkout error');
+  const fallbackLinks = document.querySelectorAll('[data-fallback-link]');
+  fallbackLinks.forEach(link => {
+    link.href = PAYMENT_LINK;
+    if (!link.textContent.trim()) {
+      link.textContent = 'open the secure Stripe portal';
     }
+  });
+
+  async function createCheckout(name, amount, email, metadata = {}) {
+    if (!amount || Number.isNaN(amount)) {
+      throw new Error('Enter a valid amount to continue.');
+    }
+
+    let response;
+    try {
+      response = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, amount, email, metadata })
+      });
+    } catch (networkError) {
+      console.error('Checkout request failed', networkError);
+      throw new Error('We could not reach our payment server. Please use the quick pay link below.');
+    }
+
+    let data = {};
+    try {
+      data = await response.json();
+    } catch (_) {
+      data = {};
+    }
+
+    if (response.ok && data.id) {
+      await stripe.redirectToCheckout({ sessionId: data.id });
+      return;
+    }
+
+    if (data.url) {
+      window.location = data.url;
+      return;
+    }
+
+    const message = data.message || response.statusText || 'We could not start checkout right now.';
+    if (/stripe secret key missing/i.test(message)) {
+      throw new Error('Online checkout is temporarily offline while we refresh our Stripe keys.');
+    }
+
+    throw new Error(message);
   }
 
-  document.getElementById('depositForm').addEventListener('submit', async (e)=>{
-    e.preventDefault();
-    const status = document.getElementById('dep_status');
-    status.textContent = 'Redirecting to Stripe…';
-    try{
-      await createCheckout('Deposit', parseFloat(document.getElementById('dep_amount').value), document.getElementById('dep_email').value, { payer: document.getElementById('dep_name').value, type:'deposit' });
-    }catch(err){ status.textContent = err.message; }
-  });
+  function updateStatus(statusEl, message) {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.classList.remove('has-error');
+  }
 
-  document.getElementById('invoiceForm').addEventListener('submit', async (e)=>{
-    e.preventDefault();
-    const status = document.getElementById('inv_status');
-    status.textContent = 'Redirecting to Stripe…';
-    try{
-      await createCheckout(`Invoice ${document.getElementById('inv_no').value}`, parseFloat(document.getElementById('inv_amount').value), document.getElementById('inv_email').value, { invoice: document.getElementById('inv_no').value, type:'invoice' });
-    }catch(err){ status.textContent = err.message; }
-  });
+  function handleCheckoutError(statusEl, error) {
+    if (!statusEl) return;
+    const message = error?.message || 'We could not start checkout right now.';
+    const fallbackMarkup = ` You can still <a href="${PAYMENT_LINK}" target="_blank" rel="noopener">open the secure Stripe portal</a>.`;
+    statusEl.innerHTML = `${message}${fallbackMarkup}`;
+    statusEl.classList.add('has-error');
+  }
 
-  // Render services from JSON
-  async function renderServices(){
-    try{
+  const depositForm = document.getElementById('depositForm');
+  if (depositForm) {
+    depositForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const statusEl = document.getElementById('dep_status');
+      updateStatus(statusEl, 'Redirecting to Stripe…');
+      const amount = parseFloat(document.getElementById('dep_amount').value);
+      const email = document.getElementById('dep_email').value;
+      const name = document.getElementById('dep_name').value;
+      try {
+        await createCheckout('Deposit', amount, email, { payer: name, type: 'deposit' });
+      } catch (error) {
+        handleCheckoutError(statusEl, error);
+      }
+    });
+  }
+
+  const invoiceForm = document.getElementById('invoiceForm');
+  if (invoiceForm) {
+    invoiceForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const statusEl = document.getElementById('inv_status');
+      updateStatus(statusEl, 'Preparing your secure link…');
+      const amount = parseFloat(document.getElementById('inv_amount').value);
+      const email = document.getElementById('inv_email').value;
+      const invoiceNumber = document.getElementById('inv_no').value;
+      try {
+        await createCheckout(`Invoice ${invoiceNumber}`, amount, email, { invoice: invoiceNumber, type: 'invoice' });
+      } catch (error) {
+        handleCheckoutError(statusEl, error);
+      }
+    });
+  }
+
+  async function renderServices() {
+    const summaryList = document.getElementById('serviceSummaryList');
+    const addonList = document.getElementById('addonSummaryList');
+    const statusEl = document.getElementById('serviceStatus');
+    if (!summaryList && !addonList) return;
+
+    try {
       const res = await fetch('data/services.json');
+      if (!res.ok) throw new Error('Network error');
       const data = await res.json();
-      const cards = document.getElementById('serviceSpotlight');
-      const details = document.getElementById('serviceDetails');
-      const addons = document.getElementById('addonServices');
-      const status = document.getElementById('serviceStatus');
 
-      const imageMap = {
-        'E‑Design (Virtual)': 'https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?q=80&w=1400&auto=format&fit=crop',
-        'Residential Room Refresh': 'https://images.unsplash.com/photo-1519710164239-da123dc03ef4?q=80&w=1400&auto=format&fit=crop',
-        'Full Residential Design (Turnkey)': 'https://images.unsplash.com/photo-1505691723518-36a5ac3b2a59?q=80&w=1400&auto=format&fit=crop',
-        'Home Staging': 'https://images.unsplash.com/photo-1484154218962-a197022b5858?q=80&w=1400&auto=format&fit=crop',
-        'Small Commercial / Boutique': 'https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?q=80&w=1400&auto=format&fit=crop'
+      const formatPrice = (item) => {
+        if (item.price) return `$${Number(item.price).toLocaleString()}`;
+        if (item.priceFrom) return `From $${Number(item.priceFrom).toLocaleString()}`;
+        return '';
       };
 
-      if(cards){
-        const highlightNames = ['E‑Design (Virtual)','Residential Room Refresh','Home Staging','Small Commercial / Boutique'];
-        const highlightItems = highlightNames.map(name => data.core.find(item => item.name === name)).filter(Boolean);
-        const featured = highlightItems.length ? highlightItems : data.core.slice(0,4);
-        cards.innerHTML = featured.map(s => `
-          <article class="service-card fx-rise">
-            <img src="${imageMap[s.name] || imageMap['Full Residential Design (Turnkey)']}" alt="${s.name}" loading="lazy" />
-            <div class="service-card__overlay">
-              <h3>${s.name}</h3>
-              <p>${s.desc}</p>
-            </div>
-          </article>
-        `).join('');
+      if (summaryList) {
+        summaryList.innerHTML = data.core.map((service) => {
+          const price = formatPrice(service);
+          return `
+            <li>
+              <div class="service-summary__title">
+                <strong>${service.name}</strong>
+                ${price ? `<span class="service-summary__price">${price}</span>` : ''}
+              </div>
+              <p>${service.desc}</p>
+            </li>
+          `;
+        }).join('');
       }
 
-      if(details){
-        details.innerHTML = data.core.map(s => `
-          <article class="feature jeton-card">
-            <h3>${s.name}</h3>
-            <p>${s.desc}</p>
-            <div class="cta-row">
-              ${s.link ? `<a class="btn btn-jeton" href="${s.link}" target="_blank" rel="noopener">Pay Now</a>` : ''}
-              ${s.price ? `<button class="btn btn-outline" data-buy data-name="${s.name}" data-amount="${s.price}">$${s.price}</button>` : ''}
-              ${s.priceFrom ? `<button class="btn btn-outline" data-buy data-name="${s.name}" data-amount="${s.priceFrom}">From $${s.priceFrom}</button>` : ''}
-            </div>
-          </article>
-        `).join('');
+      if (addonList) {
+        addonList.innerHTML = data.addons.map((addon) => {
+          const price = formatPrice(addon);
+          return `
+            <li>
+              <div class="service-summary__title">
+                <strong>${addon.name}</strong>
+                ${price ? `<span class="service-summary__price">${price}</span>` : ''}
+              </div>
+              <p>${addon.desc}</p>
+            </li>
+          `;
+        }).join('');
       }
 
-      addons.innerHTML = data.addons.map(s => `
-        <article class="feature jeton-card">
-          <h3>${s.name}</h3>
-          <p>${s.desc}</p>
-          <div class="cta-row">
-            ${s.link ? `<a class="btn btn-jeton" href="${s.link}" target="_blank" rel="noopener">Pay Now</a>` : `<button class="btn btn-outline" data-buy data-name="${s.name}" data-amount="${s.priceFrom}">From $${s.priceFrom}</button>`}
-          </div>
-        </article>
-      `).join('');
-
-      const buyButtons = document.querySelectorAll('[data-buy]');
-      buyButtons.forEach(btn => {
-        btn.addEventListener('click', async () => {
-          try{ await createCheckout(btn.dataset.name, parseFloat(btn.dataset.amount)); }
-          catch(err){ alert(err.message); }
-        });
-      });
-      if(!buyButtons.length && status){
-        status.textContent = 'Online checkout links coming soon. Use the form above for custom payment links.';
+      if (statusEl) {
+        statusEl.textContent = 'Hover or tap a line item to quickly revisit what we deliver.';
       }
-    }catch(e){
-      console.error(e);
-      if(status){ status.textContent = 'We could not load the service catalog right now. Use the forms above and we will follow up manually.'; }
+    } catch (error) {
+      console.error('Service summary failed', error);
+      if (statusEl) {
+        statusEl.textContent = 'We could not load the service snapshots right now. Let us know if you need a refresher.';
+      }
     }
   }
+
   renderServices();
   </script>
   <script async src="https://js.stripe.com/v3/buy-button.js"></script>

--- a/project-brief.html
+++ b/project-brief.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Ømnilon Interiors | Project Brief</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="style.css" />
+  <meta name="description" content="Share project goals, inspiration, and room photos with Ømnilon Interiors after booking." />
+</head>
+<body class="theme-jeton">
+  <div class="wrapper">
+    <header class="brand-header reveal fade is-visible">
+      <a href="index.html#home" class="brand" aria-label="Ømnilon Interiors">
+        <span class="brand-title">&#216;MNILON</span>
+      </a>
+    </header>
+    <nav id="siteNav">
+      <a href="index.html#home">Home</a>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#portfolio">Portfolio</a>
+      <a href="index.html#about">About</a>
+      <a href="Payment.html">Payments</a>
+      <a href="index.html#contact">Contact</a>
+    </nav>
+
+    <main>
+      <section class="hero-jeton hero reveal fx-clip" style="position:relative;">
+        <div class="bg-grid"></div>
+        <div class="hero-inner fx-rise" data-parallax="0.12">
+          <h1 class="grad-text">Project Brief</h1>
+          <p>Help us understand your spaces, priorities, and inspiration so we can tailor the design plan to you.</p>
+        </div>
+      </section>
+
+      <section class="section brief fx-rise">
+        <div class="jeton-card brief-intro">
+          <h2>What to expect</h2>
+          <p>
+            This questionnaire walks through project goals, timeline, style preferences, and existing pieces we should factor in.
+            Upload room photos or inspiration snapshots so we can see what you see. When you submit, you’ll get a summary to copy
+            into an email along with your images.
+          </p>
+          <ul class="brief-checklist">
+            <li><span>Timeline:</span> upcoming installs, move-in dates, or events we should design around.</li>
+            <li><span>Function:</span> how you need each room to work day-to-day.</li>
+            <li><span>Style:</span> the mood, palette, and any “must keep” pieces.</li>
+          </ul>
+        </div>
+
+        <form class="jeton-card brief-form" id="projectBriefForm">
+          <h2>Tell us about your project</h2>
+          <div class="brief-grid">
+            <label>
+              Your name
+              <input type="text" name="clientName" required />
+            </label>
+            <label>
+              Best email for project updates
+              <input type="email" name="clientEmail" required />
+            </label>
+            <label>
+              Phone (optional)
+              <input type="tel" name="clientPhone" inputmode="tel" />
+            </label>
+            <label>
+              Project address or neighborhood
+              <input type="text" name="projectLocation" />
+            </label>
+            <label>
+              Primary service booked
+              <select name="serviceType" required>
+                <option value="" disabled selected>Select one</option>
+                <option value="E-Design (Virtual)">E-Design (Virtual)</option>
+                <option value="Residential Room Refresh">Residential Room Refresh</option>
+                <option value="Full Residential Design (Turnkey)">Full Residential Design (Turnkey)</option>
+                <option value="Home Staging">Home Staging</option>
+                <option value="Small Commercial / Boutique">Small Commercial / Boutique</option>
+                <option value="Other">Other / Custom Scope</option>
+              </select>
+            </label>
+            <label>
+              Target install or reveal date
+              <input type="date" name="targetDate" />
+            </label>
+          </div>
+
+          <label>
+            Which rooms or areas are we focusing on?
+            <textarea name="rooms" rows="3" placeholder="E.g. primary bedroom, entryway, powder bath"></textarea>
+          </label>
+
+          <label>
+            What feeling or story should the finished space tell?
+            <textarea name="vision" rows="4" placeholder="Share the vibe, keywords, or inspiration references that feel right."></textarea>
+          </label>
+
+          <label>
+            Daily-life musts
+            <textarea name="function" rows="4" placeholder="Storage needs, kid- or pet-friendly goals, entertaining, etc."></textarea>
+          </label>
+
+          <label>
+            Pieces to keep or avoid
+            <textarea name="keepList" rows="3" placeholder="Existing furniture, heirlooms, or items to skip."></textarea>
+          </label>
+
+          <fieldset class="brief-fieldset">
+            <legend>Style direction</legend>
+            <div class="brief-grid">
+              <label>
+                Color palette love list
+                <input type="text" name="colorPalette" placeholder="Warm neutrals, jewel tones, monochrome, etc." />
+              </label>
+              <label>
+                Materials &amp; finishes you’re drawn to
+                <input type="text" name="materials" placeholder="Light oak, unlacquered brass, boucle, etc." />
+              </label>
+              <label>
+                Brands or retailers you gravitate toward
+                <input type="text" name="brands" placeholder="CB2, RH, Chairish, local makers…" />
+              </label>
+              <label>
+                Any “absolutely nots” we should steer clear of?
+                <input type="text" name="avoid" placeholder="No wallpaper, no leather, etc." />
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset class="brief-fieldset">
+            <legend>Logistics &amp; budget</legend>
+            <div class="brief-grid">
+              <label>
+                Overall investment range (furnishings, decor, trades)
+                <input type="text" name="budget" placeholder="E.g. $15k-$20k or “phase in over 6 months.”" />
+              </label>
+              <label>
+                Decision makers
+                <input type="text" name="decisionMakers" placeholder="Who will review concepts and sign off?" />
+              </label>
+              <label>
+                Preferred way to meet
+                <select name="meetingStyle">
+                  <option value="Virtual">Virtual video call</option>
+                  <option value="In person">In-person walk-through</option>
+                  <option value="Hybrid">Hybrid / mix of both</option>
+                </select>
+              </label>
+              <label>
+                Additional vendors already engaged
+                <input type="text" name="vendors" placeholder="Contractor, architect, organizer, etc." />
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset class="brief-fieldset">
+            <legend>Photos &amp; inspiration</legend>
+            <p class="mini">Attach clear photos of each room (natural light is best). We’ll remind you to email them after you submit.</p>
+            <label class="file-label">
+              Upload room photos
+              <input type="file" id="spacePhotos" name="spacePhotos" accept="image/*" multiple />
+            </label>
+            <ul class="photo-list" id="photoList">
+              <li>No photos selected yet.</li>
+            </ul>
+            <label>
+              Share any inspiration links (Pinterest, Houzz, Instagram, etc.)
+              <textarea name="inspirationLinks" rows="3" placeholder="Paste URLs or usernames we should explore."></textarea>
+            </label>
+            <label>
+              Need to send large files?
+              <input type="text" name="fileShare" placeholder="Dropbox, Google Drive, or WeTransfer link" />
+            </label>
+          </fieldset>
+
+          <label>
+            Anything else we should know?
+            <textarea name="extras" rows="3" placeholder="Allergies, security instructions, renovation context, etc."></textarea>
+          </label>
+
+          <button class="btn btn-jeton" type="submit">Generate project summary</button>
+          <p class="mini" id="briefStatus" aria-live="polite"></p>
+        </form>
+
+        <section class="jeton-card brief-summary" id="briefSummary" hidden>
+          <h2>Next step: share your brief</h2>
+          <p>
+            Copy the responses below and email them with your photos to
+            <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a>. If you selected files above, attach them to the same
+            email so we receive the full context.
+          </p>
+          <textarea id="summaryOutput" rows="12" readonly></textarea>
+          <div class="summary-actions">
+            <button type="button" class="btn btn-outline" id="copySummary">Copy summary to clipboard</button>
+            <a class="btn btn-jeton" href="mailto:omnilend.co@gmail.com?subject=Ømnilon%20Project%20Brief">Start an email</a>
+          </div>
+        </section>
+      </section>
+    </main>
+  </div>
+  <footer class="site-footer">
+    <p>&copy; 2025 Ømnilon Interiors — Atlanta, GA</p>
+  </footer>
+
+  <script defer src="script.js"></script>
+  <script defer src="questionnaire.js"></script>
+</body>
+</html>

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -1,0 +1,118 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('projectBriefForm');
+    if (!form) return;
+
+    const statusEl = document.getElementById('briefStatus');
+    const summarySection = document.getElementById('briefSummary');
+    const summaryOutput = document.getElementById('summaryOutput');
+    const copyButton = document.getElementById('copySummary');
+    const photoInput = document.getElementById('spacePhotos');
+    const photoList = document.getElementById('photoList');
+
+    const updatePhotoList = () => {
+      if (!photoList) return;
+      photoList.innerHTML = '';
+      const files = photoInput && photoInput.files ? Array.from(photoInput.files) : [];
+      if (!files.length) {
+        photoList.innerHTML = '<li>No photos selected yet.</li>';
+        return;
+      }
+
+      files.forEach((file, index) => {
+        if (index >= 12) return;
+        const item = document.createElement('li');
+        const sizeInKB = Math.max(1, Math.round(file.size / 1024));
+        item.textContent = `${file.name} (${sizeInKB.toLocaleString()} KB)`;
+        photoList.appendChild(item);
+      });
+
+      if (files.length > 12) {
+        const extra = document.createElement('li');
+        extra.textContent = `+ ${files.length - 12} more file(s)… (attach all of them when you email us)`;
+        photoList.appendChild(extra);
+      }
+    };
+
+    if (photoInput) {
+      photoInput.addEventListener('change', updatePhotoList);
+    }
+
+    const buildSection = (label, value) => {
+      if (!value) return '';
+      return `${label}: ${value}`;
+    };
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const data = new FormData(form);
+      const lines = [];
+
+      lines.push(buildSection('Client name', data.get('clientName')));
+      lines.push(buildSection('Email', data.get('clientEmail')));
+      lines.push(buildSection('Phone', data.get('clientPhone')));
+      lines.push(buildSection('Project location', data.get('projectLocation')));
+      lines.push(buildSection('Service', data.get('serviceType')));
+      lines.push(buildSection('Target date', data.get('targetDate')));
+      lines.push('--- Project scope ---');
+      lines.push(buildSection('Rooms / areas', data.get('rooms')));
+      lines.push(buildSection('Vision', data.get('vision')));
+      lines.push(buildSection('Daily-life musts', data.get('function')));
+      lines.push(buildSection('Pieces to keep / avoid', data.get('keepList')));
+      lines.push('--- Style notes ---');
+      lines.push(buildSection('Color palette', data.get('colorPalette')));
+      lines.push(buildSection('Materials & finishes', data.get('materials')));
+      lines.push(buildSection('Preferred brands / retailers', data.get('brands')));
+      lines.push(buildSection('Hard no’s', data.get('avoid')));
+      lines.push('--- Logistics ---');
+      lines.push(buildSection('Investment range', data.get('budget')));
+      lines.push(buildSection('Decision makers', data.get('decisionMakers')));
+      lines.push(buildSection('Meeting style', data.get('meetingStyle')));
+      lines.push(buildSection('Vendors already engaged', data.get('vendors')));
+      lines.push('--- Photos & inspiration ---');
+      const inspiration = buildSection('Links to inspo', data.get('inspirationLinks'));
+      if (inspiration) lines.push(inspiration);
+      const fileShare = buildSection('File share link', data.get('fileShare'));
+      if (fileShare) lines.push(fileShare);
+      const selectedPhotos = photoInput && photoInput.files ? Array.from(photoInput.files).map(file => file.name) : [];
+      if (selectedPhotos.length) {
+        lines.push(`Attached photo files: ${selectedPhotos.join(', ')}`);
+      }
+      lines.push('--- Extra notes ---');
+      lines.push(buildSection('Additional context', data.get('extras')));
+
+      const cleaned = lines.filter(Boolean).join('\n\n');
+      summaryOutput.value = cleaned || 'No responses captured.';
+      if (statusEl) {
+        statusEl.textContent = 'Summary ready! Copy it below and email it with your photos to omnilend.co@gmail.com.';
+      }
+      if (summarySection) {
+        summarySection.hidden = false;
+        summarySection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+
+    if (copyButton) {
+      copyButton.addEventListener('click', async () => {
+        if (!summaryOutput.value) {
+          if (statusEl) statusEl.textContent = 'Complete the form first so we have something to copy.';
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(summaryOutput.value);
+          copyButton.textContent = 'Copied!';
+          copyButton.classList.add('is-success');
+          setTimeout(() => {
+            copyButton.textContent = 'Copy summary to clipboard';
+            copyButton.classList.remove('is-success');
+          }, 2500);
+        } catch (error) {
+          console.error('Clipboard copy failed', error);
+          if (statusEl) {
+            statusEl.textContent = 'Select the summary text manually if your browser blocks clipboard access.';
+          }
+        }
+      });
+    }
+  });
+})();

--- a/style.css
+++ b/style.css
@@ -1124,21 +1124,57 @@ body.experience-security .menu-toggle span{ background:#9fe8f5; }
 /* CTA stripe */
 .cta-stripe{ text-align:center; background:linear-gradient(180deg,rgba(255,181,71,.06),rgba(255,181,71,.02)); border:1px solid rgba(255,255,255,.08); border-radius:14px; padding:20px; }
 /* Payment page extras */
-.payments{ display:flex; flex-direction:column; gap:26px; }
-.service-tiles{ display:grid; grid-template-columns:repeat(auto-fit, minmax(220px,1fr)); gap:18px; }
-.service-card{ position:relative; border-radius:18px; overflow:hidden; min-height:240px; background:#10141c; box-shadow:0 18px 40px rgba(0,0,0,.38); }
-.service-card img{ width:100%; height:100%; object-fit:cover; transition:transform .6s ease, filter .6s ease; filter:saturate(115%) brightness(.85); }
-.service-card__overlay{ position:absolute; inset:0; padding:20px; display:flex; flex-direction:column; justify-content:flex-end; gap:10px; background:linear-gradient(180deg, rgba(6,8,12,.05) 0%, rgba(6,8,12,.85) 100%); color:#f0f4f2; }
-.service-card__overlay h3{ font-family:'Playfair Display',serif; font-size:20px; }
-.service-card__overlay p{ font-size:15px; line-height:1.5; color:#cbd4d0; }
-.service-card:hover img{ transform:scale(1.05); filter:saturate(125%) brightness(.95); }
-.payments-subhead{ font-family:'Playfair Display',serif; margin:8px 0 6px; font-size:24px; }
-.payments .feature-grid{ gap:16px; }
-.pay-form label{ display:block; font-size:14px; margin-top:8px; margin-bottom:4px; color:#cbd4d0; }
-.pay-form input{ width:100%; margin-bottom:10px; padding:10px 12px; border-radius:8px; border:1px solid rgba(255,255,255,.15); background:#0f1217; color:#e8ecec; transition:border .2s ease, box-shadow .2s ease; }
+.payments{ display:flex; flex-direction:column; gap:32px; }
+.payment-overview{ display:flex; flex-direction:column; gap:16px; }
+.payment-checklist{ list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fit, minmax(220px,1fr)); gap:12px 18px; }
+.payment-checklist li{ background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08); border-radius:12px; padding:14px 16px; font-size:15px; line-height:1.5; display:flex; flex-direction:column; gap:4px; }
+.payment-checklist li span{ font-weight:600; text-transform:uppercase; letter-spacing:.06em; font-size:12px; color:#ffb547; }
+.payment-alert{ padding:16px 18px; border-radius:12px; border:1px solid rgba(255,181,71,.35); background:rgba(255,181,71,.08); font-size:14px; line-height:1.6; }
+.payment-alert a{ color:#ffe0b0; text-decoration:underline; text-decoration-thickness:2px; }
+.payment-grid{ display:grid; gap:18px; grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); }
+.payment-card{ display:flex; flex-direction:column; gap:12px; }
+.pay-form label{ display:block; font-size:14px; margin-top:10px; margin-bottom:4px; color:#cbd4d0; }
+.pay-form input{ width:100%; margin-bottom:6px; padding:10px 12px; border-radius:8px; border:1px solid rgba(255,255,255,.18); background:#0f1217; color:#e8ecec; transition:border .2s ease, box-shadow .2s ease; }
 .pay-form input:focus{ outline:none; border-color:#ffb547; box-shadow:0 0 0 2px rgba(255,181,71,.25); }
-.pay-form .mini{ font-size:12px; opacity:.85; min-height:18px; }
-.service-list{ display:flex; flex-direction:column; gap:8px; }
+.payment-status{ min-height:22px; }
+.payment-status.has-error{ color:#ffb8b8; }
+.payment-support-grid{ display:grid; gap:18px; grid-template-columns:repeat(auto-fit, minmax(280px,1fr)); }
+.support-card{ display:flex; flex-direction:column; gap:12px; }
+.support-card summary{ cursor:pointer; font-weight:600; font-size:16px; }
+.support-card summary::marker{ color:#ffb547; }
+.service-summary__inner{ display:flex; flex-direction:column; gap:14px; margin-top:8px; }
+.service-summary-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:14px; }
+.service-summary-list li{ background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08); border-radius:12px; padding:14px 16px; }
+.service-summary__title{ display:flex; justify-content:space-between; gap:12px; font-size:15px; }
+.service-summary__price{ font-weight:600; color:#ffb547; }
+.service-summary-list p{ margin:8px 0 0; font-size:14px; line-height:1.6; color:#d3dcda; }
+.service-summary .mini{ margin-top:4px; font-size:12px; color:#aebbbb; }
+
+.brief{ display:flex; flex-direction:column; gap:28px; }
+.brief-intro{ display:flex; flex-direction:column; gap:16px; }
+.brief-checklist{ list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fit, minmax(220px,1fr)); gap:12px 18px; font-size:15px; }
+.brief-checklist li{ background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08); border-radius:12px; padding:14px 16px; line-height:1.6; }
+.brief-checklist span{ display:block; font-weight:600; color:#ffb547; margin-bottom:6px; text-transform:uppercase; letter-spacing:.05em; font-size:12px; }
+.brief-form{ display:flex; flex-direction:column; gap:18px; }
+.brief-form h2{ margin-bottom:4px; }
+.brief-grid{ display:grid; gap:14px; grid-template-columns:repeat(auto-fit, minmax(240px,1fr)); }
+.brief-form label{ display:flex; flex-direction:column; gap:6px; font-size:14px; color:#cbd4d0; }
+.brief-form input,.brief-form textarea,.brief-form select{ width:100%; padding:10px 12px; border-radius:8px; border:1px solid rgba(255,255,255,.18); background:#0f1217; color:#e8ecec; font-size:14px; }
+.brief-form textarea{ resize:vertical; }
+.brief-form input:focus,.brief-form textarea:focus,.brief-form select:focus{ outline:none; border-color:#ffb547; box-shadow:0 0 0 2px rgba(255,181,71,.25); }
+.brief-fieldset{ border:1px solid rgba(255,255,255,.12); border-radius:14px; padding:18px; display:flex; flex-direction:column; gap:16px; }
+.brief-fieldset legend{ padding:0 6px; font-weight:600; color:#ffe0b0; }
+.file-label{ display:flex; flex-direction:column; gap:6px; font-size:14px; color:#cbd4d0; }
+.file-label input[type="file"]{ border:1px dashed rgba(255,255,255,.25); padding:18px; border-radius:12px; background:rgba(12,16,22,.7); cursor:pointer; }
+.photo-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px; font-size:13px; color:#aebbbb; }
+.brief-summary{ display:flex; flex-direction:column; gap:16px; }
+.brief-summary textarea{ width:100%; min-height:220px; padding:14px 16px; border-radius:10px; border:1px solid rgba(255,255,255,.18); background:#0f1217; color:#f0f4f2; font-size:14px; }
+.summary-actions{ display:flex; flex-wrap:wrap; gap:12px; }
+.btn.is-success,.btn.btn-outline.is-success{ background:#1f7a4d; border-color:#1f7a4d; color:#f5fff6; }
+
 @media(max-width:720px){
-  .service-tiles{ grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); }
+  .payment-checklist{ grid-template-columns:1fr; }
+  .payment-grid,.payment-support-grid{ grid-template-columns:1fr; }
+  .brief-grid{ grid-template-columns:1fr; }
+  .summary-actions{ flex-direction:column; }
 }


### PR DESCRIPTION
## Summary
- Reorganize the payment page to highlight the 50% deposit requirement, streamline the payment options, and surface a project brief call-to-action.
- Improve Stripe checkout handling with clearer status messaging and fallbacks when the backend key is missing.
- Add a dedicated project brief page and client-side questionnaire script so clients can share project goals, logistics, and photo notes after booking.

## Testing
- No automated tests were run (static site changes).


------
https://chatgpt.com/codex/tasks/task_e_68d7f6f105408321a7c96a33e331661c