### PR TITLE
Integrate project brief form with Telegram bot

### DIFF
--- a/api/_telegram.js
+++ b/api/_telegram.js
@@ -1,0 +1,54 @@
+const DEFAULT_TOKEN = '8304288828:AAFkB3-cnBtfJAZNiTua4vYeVkSXWs_7IWw';
+let cachedChatId = process.env.TELEGRAM_CHAT_ID || process.env.TELEGRAM_FALLBACK_CHAT_ID || '';
+
+export const safeTrim = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export const getTelegramToken = () => process.env.TELEGRAM_BOT_TOKEN || DEFAULT_TOKEN;
+
+export async function resolveChatId(token = getTelegramToken()) {
+    if (cachedChatId) return cachedChatId;
+    if (!token) throw new Error('Missing Telegram token');
+
+    const res = await fetch(`https://api.telegram.org/bot${token}/getUpdates`);
+    if (!res.ok) throw new Error('Unable to connect to Telegram.');
+
+    const data = await res.json();
+    const updates = Array.isArray(data?.result) ? data.result : [];
+    const latest = [...updates].reverse().find((entry) => (
+        entry?.message?.chat?.id ||
+        entry?.channel_post?.chat?.id ||
+        entry?.my_chat_member?.chat?.id ||
+        entry?.edited_message?.chat?.id
+    ));
+
+    const foundId = latest?.message?.chat?.id ||
+        latest?.channel_post?.chat?.id ||
+        latest?.my_chat_member?.chat?.id ||
+        latest?.edited_message?.chat?.id;
+
+    if (!foundId) throw new Error('Telegram chat not initialised. Send a hello to the bot first.');
+    cachedChatId = String(foundId);
+    return cachedChatId;
+}
+
+export async function sendTelegramMessage({ text, token = getTelegramToken(), chatId }) {
+    if (!token) throw new Error('Telegram bot token is not configured.');
+    const resolvedChatId = chatId || await resolveChatId(token);
+
+    const telegramUrl = `https://api.telegram.org/bot${token}/sendMessage`;
+    const telegramRes = await fetch(telegramUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            chat_id: resolvedChatId,
+            text,
+        }),
+    });
+
+    const telegramData = await telegramRes.json().catch(() => ({}));
+    if (!telegramRes.ok || telegramData?.ok === false) {
+        throw new Error(telegramData?.description || 'Telegram API rejected the message.');
+    }
+
+    return telegramData;
+}

--- a/api/sendBrief.js
+++ b/api/sendBrief.js
@@ -1,0 +1,112 @@
+import { safeTrim, getTelegramToken, resolveChatId, sendTelegramMessage } from './_telegram.js';
+
+const buildLine = (label, value) => {
+    const trimmed = safeTrim(value);
+    return trimmed ? `${label}: ${trimmed}` : '';
+};
+
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        return res.status(405).json({ message: 'Method Not Allowed' });
+    }
+
+    const {
+        clientName,
+        clientEmail,
+        clientPhone,
+        projectLocation,
+        serviceType,
+        targetDate,
+        rooms,
+        vision,
+        function: functionNeeds,
+        keepList,
+        colorPalette,
+        materials,
+        brands,
+        avoid,
+        budget,
+        decisionMakers,
+        meetingStyle,
+        vendors,
+        inspirationLinks,
+        fileShare,
+        extras,
+        summary,
+        photoNames = [],
+    } = req.body || {};
+
+    const nameValue = safeTrim(clientName);
+    const emailValue = safeTrim(clientEmail);
+
+    if (!nameValue || !emailValue) {
+        return res.status(400).json({ message: 'Name and email are required.' });
+    }
+
+    const telegramToken = getTelegramToken();
+    if (!telegramToken) {
+        return res.status(500).json({ message: 'Telegram bot token is not configured.' });
+    }
+
+    let chatId;
+    try {
+        chatId = await resolveChatId(telegramToken);
+    } catch (err) {
+        console.error('Telegram chat resolution error:', err);
+        return res.status(500).json({ message: err.message || 'Unable to resolve Telegram chat.' });
+    }
+
+    const formattedSummary = safeTrim(summary);
+    const photoLabel = Array.isArray(photoNames) && photoNames.length
+        ? `Selected photo placeholders: ${photoNames.join(', ')}`
+        : '';
+
+    const textSections = [
+        'ømnilon Int. — Project Brief Received',
+        '',
+        buildLine('Client', clientName),
+        buildLine('Email', clientEmail),
+        buildLine('Phone', clientPhone),
+        buildLine('Location', projectLocation),
+        buildLine('Primary service', serviceType),
+        buildLine('Target date', targetDate),
+        '',
+        '--- Project scope ---',
+        buildLine('Rooms / areas', rooms),
+        buildLine('Vision', vision),
+        buildLine('Daily-life musts', functionNeeds),
+        buildLine('Pieces to keep / avoid', keepList),
+        '',
+        '--- Style notes ---',
+        buildLine('Color palette', colorPalette),
+        buildLine('Materials & finishes', materials),
+        buildLine('Preferred brands', brands),
+        buildLine('Hard no’s', avoid),
+        '',
+        '--- Logistics ---',
+        buildLine('Investment range', budget),
+        buildLine('Decision makers', decisionMakers),
+        buildLine('Meeting style', meetingStyle),
+        buildLine('Vendors already engaged', vendors),
+        '',
+        '--- Inspiration & files ---',
+        buildLine('Inspiration links', inspirationLinks),
+        buildLine('File share link', fileShare),
+        photoLabel,
+        '',
+        '--- Additional notes ---',
+        buildLine('Extras', extras),
+    ].filter(Boolean);
+
+    if (formattedSummary) {
+        textSections.push('', '--- Formatted summary ---', formattedSummary);
+    }
+
+    try {
+        await sendTelegramMessage({ text: textSections.join('\n'), token: telegramToken, chatId });
+        res.status(200).json({ message: 'Your brief has been forwarded to the studio.' });
+    } catch (error) {
+        console.error('Telegram send error:', error);
+        res.status(500).json({ message: 'Failed to forward project brief to Telegram.' });
+    }
+}

--- a/api/sendMessage.js
+++ b/api/sendMessage.js
@@ -1,25 +1,4 @@
-const DEFAULT_TOKEN = '8304288828:AAFkB3-cnBtfJAZNiTua4vYeVkSXWs_7IWw';
-let cachedChatId = process.env.TELEGRAM_CHAT_ID || process.env.TELEGRAM_FALLBACK_CHAT_ID || '';
-
-const safeTrim = (value) => (typeof value === 'string' ? value.trim() : '');
-
-async function resolveChatId(token) {
-    if (cachedChatId) return cachedChatId;
-    if (!token) throw new Error('Missing Telegram token');
-
-    const res = await fetch(`https://api.telegram.org/bot${token}/getUpdates`);
-    if (!res.ok) throw new Error('Unable to connect to Telegram.');
-
-    const data = await res.json();
-    const updates = Array.isArray(data?.result) ? data.result : [];
-    const latest = [...updates].reverse().find((entry) => {
-        return entry?.message?.chat?.id || entry?.channel_post?.chat?.id || entry?.my_chat_member?.chat?.id || entry?.edited_message?.chat?.id;
-    });
-    const foundId = latest?.message?.chat?.id || latest?.channel_post?.chat?.id || latest?.my_chat_member?.chat?.id || latest?.edited_message?.chat?.id;
-    if (!foundId) throw new Error('Telegram chat not initialised. Send a hello to the bot first.');
-    cachedChatId = String(foundId);
-    return cachedChatId;
-}
+import { safeTrim, getTelegramToken, resolveChatId, sendTelegramMessage } from './_telegram.js';
 
 export default async function handler(req, res) {
     if (req.method !== 'POST') {
@@ -40,7 +19,7 @@ export default async function handler(req, res) {
         return res.status(400).json({ message: 'Name, email, and a project summary are required.' });
     }
 
-    const telegramToken = process.env.TELEGRAM_BOT_TOKEN || DEFAULT_TOKEN;
+    const telegramToken = getTelegramToken();
     if (!telegramToken) {
         return res.status(500).json({ message: 'Telegram bot token is not configured.' });
     }
@@ -83,25 +62,8 @@ export default async function handler(req, res) {
         messageValue || 'n/a'
     ].join('\n');
 
-    const telegramUrl = `https://api.telegram.org/bot${telegramToken}/sendMessage`;
-
     try {
-        const telegramRes = await fetch(telegramUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                chat_id: chatId,
-                text,
-            }),
-        });
-
-        const telegramData = await telegramRes.json().catch(() => ({}));
-        if (!telegramRes.ok || telegramData?.ok === false) {
-            throw new Error(telegramData?.description || 'Telegram API rejected the message.');
-        }
-
+        await sendTelegramMessage({ text, token: telegramToken, chatId });
         res.status(200).json({ message: 'Message sent successfully.' });
     } catch (error) {
         console.error('Telegram send error:', error);

--- a/project-brief.html
+++ b/project-brief.html
@@ -28,7 +28,7 @@
         <div class="bg-grid"></div>
         <div class="hero-inner fx-rise" data-parallax="0.12">
           <h1 class="grad-text">Project Brief</h1>
-          <p>Help us understand your spaces, priorities, and inspiration so we can tailor the design plan to you.</p>
+          <p>Help us understand your spaces, priorities, and inspiration so we can tailor the design plan to you. When you submit, your answers go straight to our studio’s Telegram inbox.</p>
         </div>
       </section>
 
@@ -177,16 +177,15 @@
             <textarea name="extras" rows="3" placeholder="Allergies, security instructions, renovation context, etc."></textarea>
           </label>
 
-          <button class="btn btn-jeton" type="submit">Generate project summary</button>
+          <button class="btn btn-jeton" type="submit">Send project brief</button>
           <p class="mini" id="briefStatus" aria-live="polite"></p>
         </form>
 
         <section class="jeton-card brief-summary" id="briefSummary" hidden>
           <h2>Next step: share your brief</h2>
           <p>
-            Copy the responses below and email them with your photos to
-            <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a>. If you selected files above, attach them to the same
-            email so we receive the full context.
+            We’ve forwarded your responses directly to our team. Save a copy below for your records, and email room photos or large
+            files to <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a> so we have visuals alongside your brief.
           </p>
           <textarea id="summaryOutput" rows="12" readonly></textarea>
           <div class="summary-actions">

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -9,6 +9,7 @@
     const copyButton = document.getElementById('copySummary');
     const photoInput = document.getElementById('spacePhotos');
     const photoList = document.getElementById('photoList');
+    const submitBtn = form.querySelector('button[type="submit"]');
 
     const updatePhotoList = () => {
       if (!photoList) return;
@@ -43,52 +44,98 @@
       return `${label}: ${value}`;
     };
 
-    form.addEventListener('submit', (event) => {
-      event.preventDefault();
-      const data = new FormData(form);
+    const buildSummary = (formData, selectedPhotos) => {
       const lines = [];
 
-      lines.push(buildSection('Client name', data.get('clientName')));
-      lines.push(buildSection('Email', data.get('clientEmail')));
-      lines.push(buildSection('Phone', data.get('clientPhone')));
-      lines.push(buildSection('Project location', data.get('projectLocation')));
-      lines.push(buildSection('Service', data.get('serviceType')));
-      lines.push(buildSection('Target date', data.get('targetDate')));
+      lines.push(buildSection('Client name', formData.get('clientName')));
+      lines.push(buildSection('Email', formData.get('clientEmail')));
+      lines.push(buildSection('Phone', formData.get('clientPhone')));
+      lines.push(buildSection('Project location', formData.get('projectLocation')));
+      lines.push(buildSection('Service', formData.get('serviceType')));
+      lines.push(buildSection('Target date', formData.get('targetDate')));
       lines.push('--- Project scope ---');
-      lines.push(buildSection('Rooms / areas', data.get('rooms')));
-      lines.push(buildSection('Vision', data.get('vision')));
-      lines.push(buildSection('Daily-life musts', data.get('function')));
-      lines.push(buildSection('Pieces to keep / avoid', data.get('keepList')));
+      lines.push(buildSection('Rooms / areas', formData.get('rooms')));
+      lines.push(buildSection('Vision', formData.get('vision')));
+      lines.push(buildSection('Daily-life musts', formData.get('function')));
+      lines.push(buildSection('Pieces to keep / avoid', formData.get('keepList')));
       lines.push('--- Style notes ---');
-      lines.push(buildSection('Color palette', data.get('colorPalette')));
-      lines.push(buildSection('Materials & finishes', data.get('materials')));
-      lines.push(buildSection('Preferred brands / retailers', data.get('brands')));
-      lines.push(buildSection('Hard no’s', data.get('avoid')));
+      lines.push(buildSection('Color palette', formData.get('colorPalette')));
+      lines.push(buildSection('Materials & finishes', formData.get('materials')));
+      lines.push(buildSection('Preferred brands / retailers', formData.get('brands')));
+      lines.push(buildSection('Hard no’s', formData.get('avoid')));
       lines.push('--- Logistics ---');
-      lines.push(buildSection('Investment range', data.get('budget')));
-      lines.push(buildSection('Decision makers', data.get('decisionMakers')));
-      lines.push(buildSection('Meeting style', data.get('meetingStyle')));
-      lines.push(buildSection('Vendors already engaged', data.get('vendors')));
+      lines.push(buildSection('Investment range', formData.get('budget')));
+      lines.push(buildSection('Decision makers', formData.get('decisionMakers')));
+      lines.push(buildSection('Meeting style', formData.get('meetingStyle')));
+      lines.push(buildSection('Vendors already engaged', formData.get('vendors')));
       lines.push('--- Photos & inspiration ---');
-      const inspiration = buildSection('Links to inspo', data.get('inspirationLinks'));
+      const inspiration = buildSection('Links to inspo', formData.get('inspirationLinks'));
       if (inspiration) lines.push(inspiration);
-      const fileShare = buildSection('File share link', data.get('fileShare'));
+      const fileShare = buildSection('File share link', formData.get('fileShare'));
       if (fileShare) lines.push(fileShare);
-      const selectedPhotos = photoInput && photoInput.files ? Array.from(photoInput.files).map(file => file.name) : [];
       if (selectedPhotos.length) {
         lines.push(`Attached photo files: ${selectedPhotos.join(', ')}`);
       }
       lines.push('--- Extra notes ---');
-      lines.push(buildSection('Additional context', data.get('extras')));
+      lines.push(buildSection('Additional context', formData.get('extras')));
 
-      const cleaned = lines.filter(Boolean).join('\n\n');
-      summaryOutput.value = cleaned || 'No responses captured.';
+      return lines.filter(Boolean).join('\n\n');
+    };
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const files = photoInput && photoInput.files ? Array.from(photoInput.files) : [];
+      const photoNames = files.map((file) => file.name);
+      const summary = buildSummary(formData, photoNames);
+
+      const payload = {};
+      formData.forEach((value, key) => {
+        if (value instanceof File) return;
+        payload[key] = typeof value === 'string' ? value.trim() : value;
+      });
+
+      payload.photoNames = photoNames;
+      payload.summary = summary;
+
       if (statusEl) {
-        statusEl.textContent = 'Summary ready! Copy it below and email it with your photos to omnilend.co@gmail.com.';
+        statusEl.textContent = 'Sending your brief to our studio…';
       }
-      if (summarySection) {
-        summarySection.hidden = false;
-        summarySection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      if (submitBtn) submitBtn.disabled = true;
+
+      try {
+        const response = await fetch('/api/sendBrief', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+
+        const result = await response.json().catch(() => ({}));
+
+        if (response.ok) {
+          if (statusEl) {
+            statusEl.textContent = result.message || 'Thanks! Your project brief is in our Telegram queue.';
+          }
+          summaryOutput.value = summary || 'No responses captured.';
+          if (summarySection) {
+            summarySection.hidden = false;
+            summarySection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+          form.reset();
+          updatePhotoList();
+        } else {
+          const errorMessage = result.message || 'We could not deliver your brief. Please try again shortly.';
+          if (statusEl) statusEl.textContent = errorMessage;
+        }
+      } catch (error) {
+        console.error('Brief submission error:', error);
+        if (statusEl) {
+          statusEl.textContent = 'We hit a network issue sending to Telegram. Copy your responses and email them instead.';
+        }
+        summaryOutput.value = summary || '';
+        if (summarySection) summarySection.hidden = false;
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
       }
     });
 

--- a/style.css
+++ b/style.css
@@ -780,7 +780,8 @@ body {
     list-style: none;
     margin-top: 12px;
     padding-left: 0;
-    color: #b9c4c4;
+    color: #f1f6f6;
+    font-weight: 500;
 }
 
 .contact-meta li + li {
@@ -788,8 +789,14 @@ body {
 }
 
 .contact-meta a {
-    color: inherit;
+    color: #ffcf7a;
     text-decoration: underline;
+    font-weight: 600;
+}
+
+.contact-meta a:hover,
+.contact-meta a:focus-visible {
+    color: #ffdfa7;
 }
 
 body.experience-interiors .experience-pill[data-switch-experience="security"] {
@@ -964,6 +971,9 @@ body.experience-security #scrollProgress {
 #securityExperience .contact-form textarea:focus { border-color: #22ffd7; box-shadow: 0 0 0 2px rgba(34, 255, 215, 0.22); }
 #securityExperience .contact-form button { background: linear-gradient(90deg, #22ffd7, #17c6ff); color: #03141d; }
 #securityExperience .contact-meta { color: #96dce4; }
+#securityExperience .contact-meta a { color: #6fe3ff; }
+#securityExperience .contact-meta a:hover,
+#securityExperience .contact-meta a:focus-visible { color: #9af0ff; }
 
 .grad-text{ background: linear-gradient(92deg,#ffffff 0%, #e1f0e7 35%, #ffb547 80%); -webkit-background-clip:text; background-clip:text; color:transparent; }
 


### PR DESCRIPTION
## Summary
- add a shared Telegram helper and new API route to forward project brief submissions
- update the project brief form UI to send responses to Telegram while preserving the downloadable summary
- brighten home page contact details for better contrast against the background

## Testing
- not run (static site update)


------
https://chatgpt.com/codex/tasks/task_e_68d807361e6083219e7c5a79be24b910