### PR TITLE
Improve quick pay workflow and contact text contrast

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -76,6 +76,9 @@
               <h3>Quick pay portal</h3>
               <p>Prefer to handle it yourself? Use our ready-to-go Stripe checkout link.</p>
             </div>
+            <p class="quick-pay-note" id="quickPayNote" aria-live="polite">
+              Enter your deposit or invoice total in the quick pay portal to continue to Stripe.
+            </p>
             <stripe-buy-button
               buy-button-id="buy_btn_1SByhQ2dSpsiXnOLd7LObOHQ"
               publishable-key="pk_live_51S7wAs2dSpsiXnOLBxKLtF0iAkgXgMr7QMn0TAo9fDIbiJXbfCOwyNzMErUJ5OcIUWityN0FaXjjRh2KyxRBFNNo00RheMkkDi"
@@ -124,12 +127,22 @@
   <script>
   const PAYMENT_LINK = 'https://buy.stripe.com/4gM6oA6sH9S59ao3NgbEA01';
   const fallbackLinks = document.querySelectorAll('[data-fallback-link]');
-  fallbackLinks.forEach(link => {
-    link.href = PAYMENT_LINK;
-    if (!link.textContent.trim()) {
-      link.textContent = 'open the secure Stripe portal';
-    }
-  });
+
+  function setFallbackLinks(url) {
+    fallbackLinks.forEach((link) => {
+      link.href = url;
+      if (!link.textContent.trim()) {
+        link.textContent = 'open the secure Stripe portal';
+      }
+    });
+  }
+
+  setFallbackLinks(PAYMENT_LINK);
+
+  const quickPayCard = document.querySelector('.payment-card.quick-pay');
+  const quickPayNote = document.getElementById('quickPayNote');
+  const serviceLinkButton = document.getElementById('serviceLink');
+  let quickPayHighlightTimer;
 
   function formatCurrency(value) {
     const number = Number(value);
@@ -140,6 +153,68 @@
       currency: 'USD',
       minimumFractionDigits: hasCents ? 2 : 0,
       maximumFractionDigits: hasCents ? 2 : 0
+    });
+  }
+
+  function buildPaymentUrl(amount) {
+    try {
+      const url = new URL(PAYMENT_LINK);
+      if (typeof amount === 'number' && !Number.isNaN(amount) && amount > 0) {
+        url.searchParams.set('amount', Math.max(0, Math.round(amount * 100)).toString());
+      } else {
+        url.searchParams.delete('amount');
+      }
+      return url.toString();
+    } catch (error) {
+      console.warn('Could not construct payment URL', error);
+      return PAYMENT_LINK;
+    }
+  }
+
+  function updateQuickPayPortal({ amount, serviceName, highlight = false }) {
+    const paymentUrl = buildPaymentUrl(amount);
+    setFallbackLinks(paymentUrl);
+
+    if (quickPayNote) {
+      if (typeof amount === 'number' && !Number.isNaN(amount) && amount > 0) {
+        const label = serviceName || 'your selection';
+        quickPayNote.textContent = `We’ll route you through the quick pay portal with a ${formatCurrency(amount)} deposit for ${label}.`;
+      } else {
+        quickPayNote.textContent = 'Enter your deposit or invoice total in the quick pay portal to continue to Stripe.';
+      }
+    }
+
+    if (quickPayCard) {
+      if (highlight) {
+        quickPayCard.classList.add('is-active');
+        if (quickPayHighlightTimer) clearTimeout(quickPayHighlightTimer);
+        quickPayHighlightTimer = setTimeout(() => {
+          quickPayCard.classList.remove('is-active');
+        }, 3200);
+      } else {
+        quickPayCard.classList.remove('is-active');
+      }
+    }
+
+    return paymentUrl;
+  }
+
+  if (serviceLinkButton) {
+    serviceLinkButton.addEventListener('click', (event) => {
+      const amountValue = parseFloat(serviceLinkButton.dataset.checkoutAmount || '');
+      const serviceName = serviceLinkButton.dataset.serviceName || '';
+      const hasAmount = !Number.isNaN(amountValue) && amountValue > 0;
+      const paymentUrl = updateQuickPayPortal({
+        amount: hasAmount ? amountValue : null,
+        serviceName,
+        highlight: true
+      });
+
+      event.preventDefault();
+      window.open(paymentUrl, '_blank', 'noopener');
+      if (quickPayCard) {
+        quickPayCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
     });
   }
 
@@ -210,33 +285,30 @@
           ? service.priceFrom * 0.5
           : null;
 
+      const depositAmount = typeof preciseDeposit === 'number' && !Number.isNaN(preciseDeposit) && preciseDeposit > 0
+        ? preciseDeposit
+        : null;
+
+      const paymentUrl = updateQuickPayPortal({
+        amount: depositAmount,
+        serviceName: service.name
+      });
+
       if (linkEl) {
-        const baseLink = service.link || PAYMENT_LINK;
-
-        if (baseLink) {
-          let checkoutLink = baseLink;
-          if (preciseDeposit) {
-            try {
-              const url = new URL(baseLink, window.location.origin);
-              const amountInCents = Math.max(0, Math.round(preciseDeposit * 100));
-              url.searchParams.set('amount', amountInCents.toString());
-              checkoutLink = url.toString();
-            } catch (error) {
-              console.warn('Invalid checkout link provided for service', service.name, error);
-            }
-          }
-
-          linkEl.href = checkoutLink;
+        if (paymentUrl) {
+          linkEl.href = paymentUrl;
           linkEl.hidden = false;
           linkEl.textContent = 'Start instant checkout';
+          linkEl.dataset.checkoutAmount = depositAmount ? depositAmount.toString() : '';
+          linkEl.dataset.serviceName = service.name || '';
         } else {
           linkEl.hidden = true;
         }
       }
 
       if (helperEl) {
-        helperEl.textContent = service.link
-          ? 'Instant checkout opens in a new secure Stripe window.'
+        helperEl.textContent = depositAmount
+          ? 'Click “Start instant checkout” to queue the quick pay portal and open Stripe in a new tab.'
           : 'Use the quick pay portal below and enter the amount shown to finish booking.';
       }
     }

--- a/style.css
+++ b/style.css
@@ -780,7 +780,7 @@ body {
     list-style: none;
     margin-top: 12px;
     padding-left: 0;
-    color: #f1f6f6;
+    color: #273541;
     font-weight: 500;
 }
 
@@ -789,14 +789,14 @@ body {
 }
 
 .contact-meta a {
-    color: #ffcf7a;
+    color: #9a5b0a;
     text-decoration: underline;
     font-weight: 600;
 }
 
 .contact-meta a:hover,
 .contact-meta a:focus-visible {
-    color: #ffdfa7;
+    color: #c97712;
 }
 
 body.experience-interiors .experience-pill[data-switch-experience="security"] {
@@ -1159,9 +1159,12 @@ body.experience-security .menu-toggle span{ background:#9fe8f5; }
 .service-details p{ margin:0; }
 .service-price{ font-weight:600; color:#dfe6e2; }
 .deposit-callout{ font-weight:600; color:#ffb547; font-size:16px; }
-.payment-card.quick-pay{ align-items:center; text-align:center; gap:16px; }
+.payment-card.quick-pay{ align-items:center; text-align:center; gap:16px; position:relative; transition: box-shadow .3s ease, transform .3s ease; }
 .quick-pay__copy{ display:flex; flex-direction:column; gap:6px; align-items:center; text-align:center; }
 .payment-card.quick-pay stripe-buy-button{ align-self:center; width:100%; max-width:320px; }
+.quick-pay-note{ margin:0; font-size:15px; line-height:1.6; color:#dbe7e4; }
+.payment-card.quick-pay.is-active{ box-shadow:0 0 0 3px rgba(255,181,71,.35), 0 18px 42px rgba(0,0,0,.45); transform:translateY(-2px); }
+.payment-card.quick-pay.is-active .quick-pay-note{ color:#fff4dc; }
 .payment-support-grid{ display:grid; gap:18px; grid-template-columns:repeat(auto-fit, minmax(280px,1fr)); }
 .support-card{ display:flex; flex-direction:column; gap:12px; }
 .support-card summary{ cursor:pointer; font-weight:600; font-size:16px; }


### PR DESCRIPTION
## Summary
- guide “Start instant checkout” through the quick pay portal, including deposit-aware messaging and highlighting
- add a live-updating quick pay note and fallback link logic that forwards users to the working Stripe payment portal
- increase the contrast of contact details for better readability on light backgrounds

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d83e489a248321ac9ef0c02ad18748