### PR TITLE
Fix Stripe checkout button flow and update contact styling

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -156,23 +156,18 @@
     });
   }
 
-  function buildPaymentUrl(amount) {
+  function buildPaymentUrl(baseUrl = PAYMENT_LINK) {
+    if (!baseUrl) return '';
     try {
-      const url = new URL(PAYMENT_LINK);
-      if (typeof amount === 'number' && !Number.isNaN(amount) && amount > 0) {
-        url.searchParams.set('amount', Math.max(0, Math.round(amount * 100)).toString());
-      } else {
-        url.searchParams.delete('amount');
-      }
-      return url.toString();
+      return new URL(baseUrl).toString();
     } catch (error) {
       console.warn('Could not construct payment URL', error);
-      return PAYMENT_LINK;
+      return baseUrl;
     }
   }
 
-  function updateQuickPayPortal({ amount, serviceName, highlight = false }) {
-    const paymentUrl = buildPaymentUrl(amount);
+  function updateQuickPayPortal({ amount, serviceName, highlight = false, baseLink }) {
+    const paymentUrl = buildPaymentUrl(baseLink || PAYMENT_LINK);
     setFallbackLinks(paymentUrl);
 
     if (quickPayNote) {
@@ -200,18 +195,18 @@
   }
 
   if (serviceLinkButton) {
-    serviceLinkButton.addEventListener('click', (event) => {
+    serviceLinkButton.addEventListener('click', () => {
       const amountValue = parseFloat(serviceLinkButton.dataset.checkoutAmount || '');
       const serviceName = serviceLinkButton.dataset.serviceName || '';
+      const checkoutUrl = serviceLinkButton.dataset.checkoutUrl || PAYMENT_LINK;
       const hasAmount = !Number.isNaN(amountValue) && amountValue > 0;
-      const paymentUrl = updateQuickPayPortal({
+      updateQuickPayPortal({
         amount: hasAmount ? amountValue : null,
         serviceName,
-        highlight: true
+        highlight: true,
+        baseLink: checkoutUrl
       });
 
-      event.preventDefault();
-      window.open(paymentUrl, '_blank', 'noopener');
       if (quickPayCard) {
         quickPayCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
@@ -289,9 +284,11 @@
         ? preciseDeposit
         : null;
 
+      const baseLink = service.link || PAYMENT_LINK;
       const paymentUrl = updateQuickPayPortal({
         amount: depositAmount,
-        serviceName: service.name
+        serviceName: service.name,
+        baseLink
       });
 
       if (linkEl) {
@@ -301,6 +298,7 @@
           linkEl.textContent = 'Start instant checkout';
           linkEl.dataset.checkoutAmount = depositAmount ? depositAmount.toString() : '';
           linkEl.dataset.serviceName = service.name || '';
+          linkEl.dataset.checkoutUrl = baseLink;
         } else {
           linkEl.hidden = true;
         }

--- a/style.css
+++ b/style.css
@@ -789,14 +789,14 @@ body {
 }
 
 .contact-meta a {
-    color: #9a5b0a;
+    color: #cc5a1f;
     text-decoration: underline;
     font-weight: 600;
 }
 
 .contact-meta a:hover,
 .contact-meta a:focus-visible {
-    color: #c97712;
+    color: #e87428;
 }
 
 body.experience-interiors .experience-pill[data-switch-experience="security"] {


### PR DESCRIPTION
## Summary
- ensure the “Start instant checkout” button opens the configured Stripe link while still highlighting the quick pay portal instead of forcing a scripted pop-up
- allow service-specific checkout URLs without appending unsupported query parameters
- recolor the contact email and phone links to a burnt orange tone

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d844b75a5c8321b1c23a8666b206f3