### PR TITLE
Prefill quick pay portal with selected deposit amounts

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -79,14 +79,33 @@
             <p class="quick-pay-note" id="quickPayNote" aria-live="polite">
               Enter your deposit or invoice total in the quick pay portal to continue to Stripe.
             </p>
-            <stripe-buy-button
-              buy-button-id="buy_btn_1SByhQ2dSpsiXnOLd7LObOHQ"
-              publishable-key="pk_live_51S7wAs2dSpsiXnOLBxKLtF0iAkgXgMr7QMn0TAo9fDIbiJXbfCOwyNzMErUJ5OcIUWityN0FaXjjRh2KyxRBFNNo00RheMkkDi"
-            >
-            </stripe-buy-button>
-            <p class="mini">
-              If the button doesn’t load, <a data-fallback-link target="_blank" rel="noopener">open the secure Stripe portal</a>.
-            </p>
+            <form class="quick-pay__form" id="quickPayForm" novalidate>
+              <div class="quick-pay__field">
+                <label for="quickPayAmount">Amount</label>
+                <div class="quick-pay__input-wrapper">
+                  <span aria-hidden="true">$</span>
+                  <input
+                    type="number"
+                    id="quickPayAmount"
+                    name="amount"
+                    class="quick-pay__input"
+                    inputmode="decimal"
+                    step="0.01"
+                    min="1"
+                    required
+                    aria-describedby="quickPayError quickPayHelper"
+                  />
+                </div>
+                <p class="mini" id="quickPayHelper">You can adjust the amount before continuing if needed.</p>
+              </div>
+              <div class="quick-pay__selection" id="quickPaySelection" hidden>
+                Paying for <span id="quickPayServiceName"></span>
+              </div>
+              <div class="quick-pay__actions">
+                <button type="submit" class="btn btn-jeton" id="quickPaySubmit">Buy</button>
+                <p class="mini quick-pay__error" id="quickPayError" role="alert"></p>
+              </div>
+            </form>
           </article>
         </div>
 
@@ -131,9 +150,17 @@
   const fallbackLinks = document.querySelectorAll('[data-fallback-link]');
   const quickPayCard = document.querySelector('.payment-card.quick-pay');
   const quickPayNote = document.getElementById('quickPayNote');
+  const quickPayForm = document.getElementById('quickPayForm');
+  const quickPayAmountInput = document.getElementById('quickPayAmount');
+  const quickPaySubmitButton = document.getElementById('quickPaySubmit');
+  const quickPayErrorEl = document.getElementById('quickPayError');
+  const quickPaySelection = document.getElementById('quickPaySelection');
+  const quickPayServiceNameEl = document.getElementById('quickPayServiceName');
+  const quickPayHelper = document.getElementById('quickPayHelper');
   const serviceLinkButton = document.getElementById('serviceLink');
   const helperTextEl = document.getElementById('serviceHelperText');
   const defaultServiceButtonLabel = serviceLinkButton ? serviceLinkButton.textContent.trim() : '';
+  const defaultQuickPayButtonLabel = quickPaySubmitButton ? quickPaySubmitButton.textContent.trim() : '';
   let quickPayHighlightTimer;
   let stripeClient = null;
   let checkoutInFlight = false;
@@ -165,6 +192,15 @@
       minimumFractionDigits: hasCents ? 2 : 0,
       maximumFractionDigits: hasCents ? 2 : 0
     });
+  }
+
+  function formatAmountForInput(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) return '';
+    const cents = Math.round(value * 100);
+    if (cents % 100 === 0) {
+      return String(cents / 100);
+    }
+    return (cents / 100).toFixed(2);
   }
 
   function isValidHttpUrl(value) {
@@ -200,9 +236,30 @@
     }
   }
 
+  function setQuickPayButtonLoading(isLoading) {
+    if (!quickPaySubmitButton) return;
+    if (isLoading) {
+      quickPaySubmitButton.textContent = 'Redirecting…';
+      quickPaySubmitButton.setAttribute('aria-busy', 'true');
+      quickPaySubmitButton.classList.add('is-loading');
+      quickPaySubmitButton.disabled = true;
+    } else {
+      quickPaySubmitButton.textContent = defaultQuickPayButtonLabel || 'Buy';
+      quickPaySubmitButton.removeAttribute('aria-busy');
+      quickPaySubmitButton.classList.remove('is-loading');
+      quickPaySubmitButton.disabled = false;
+    }
+  }
+
   function reportCheckoutError(message) {
     if (helperTextEl && message) {
       helperTextEl.textContent = message;
+    }
+  }
+
+  function reportQuickPayError(message) {
+    if (quickPayErrorEl) {
+      quickPayErrorEl.textContent = message || '';
     }
   }
 
@@ -282,12 +339,40 @@
     const paymentUrl = buildPaymentUrl(baseLink || PAYMENT_LINK);
     setFallbackLinks(paymentUrl);
 
+    const hasAmount = typeof amount === 'number' && !Number.isNaN(amount) && amount > 0;
+
+    if (quickPayAmountInput) {
+      quickPayAmountInput.value = hasAmount ? formatAmountForInput(amount) : '';
+    }
+
+    if (quickPayForm) {
+      quickPayForm.dataset.serviceName = serviceName || '';
+    }
+
+    if (quickPayServiceNameEl && quickPaySelection) {
+      if (serviceName) {
+        quickPaySelection.hidden = false;
+        quickPayServiceNameEl.textContent = serviceName;
+      } else {
+        quickPaySelection.hidden = true;
+        quickPayServiceNameEl.textContent = '';
+      }
+    }
+
     if (quickPayNote) {
-      if (typeof amount === 'number' && !Number.isNaN(amount) && amount > 0) {
+      if (hasAmount) {
         const label = serviceName || 'your selection';
-        quickPayNote.textContent = `We’ll route you through the quick pay portal with a ${formatCurrency(amount)} deposit for ${label}.`;
+        quickPayNote.textContent = `We’ll route you through the quick pay portal with a ${formatCurrency(amount)} deposit for ${label}. You can adjust the amount before continuing.`;
       } else {
         quickPayNote.textContent = 'Enter your deposit or invoice total in the quick pay portal to continue to Stripe.';
+      }
+    }
+
+    if (quickPayHelper) {
+      if (hasAmount) {
+        quickPayHelper.textContent = 'Need to tweak it? Edit the amount before tapping Buy.';
+      } else {
+        quickPayHelper.textContent = 'You can adjust the amount before continuing if needed.';
       }
     }
 
@@ -301,6 +386,10 @@
       } else {
         quickPayCard.classList.remove('is-active');
       }
+    }
+
+    if (hasAmount) {
+      reportQuickPayError('');
     }
 
     return paymentUrl;
@@ -333,6 +422,73 @@
         amount: hasAmount ? amountValue : null,
         serviceName
       });
+    });
+  }
+
+  if (quickPayForm) {
+    quickPayForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      if (!quickPayAmountInput) return;
+
+      const rawAmount = quickPayAmountInput.value || '';
+      const amount = parseFloat(rawAmount);
+      const serviceName = quickPayForm.dataset.serviceName || '';
+
+      if (Number.isNaN(amount) || amount <= 0) {
+        reportQuickPayError('Enter a valid amount above to continue.');
+        quickPayAmountInput.focus();
+        return;
+      }
+
+      const stripe = await ensureStripeClient();
+      if (!stripe) {
+        reportQuickPayError('We couldn’t initialise Stripe. Message the studio and we’ll send a direct payment link.');
+        return;
+      }
+
+      if (checkoutInFlight) return;
+      checkoutInFlight = true;
+      setQuickPayButtonLoading(true);
+      reportQuickPayError('');
+
+      try {
+        const response = await fetch(CHECKOUT_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: `${serviceName || 'Design Project'} Payment`,
+            amount,
+            metadata: {
+              service: serviceName || '',
+              source: 'quick-pay-portal'
+            }
+          })
+        });
+
+        if (!response.ok) {
+          throw new Error(`Checkout request failed: ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (payload?.url) {
+          window.location.href = payload.url;
+          return;
+        }
+
+        if (payload?.id) {
+          const { error } = await stripe.redirectToCheckout({ sessionId: payload.id });
+          if (error) throw error;
+        } else {
+          throw new Error('Missing checkout session data');
+        }
+      } catch (error) {
+        console.error('Quick pay checkout failed', error);
+        reportQuickPayError('We couldn’t open Stripe automatically. Try again or message the studio for help.');
+      } finally {
+        checkoutInFlight = false;
+        setQuickPayButtonLoading(false);
+      }
     });
   }
 
@@ -443,8 +599,8 @@
       if (helperEl) {
         if (depositAmount) {
           helperEl.textContent = hasDirectLink
-            ? 'Click “Start instant checkout” to queue the quick pay portal and open Stripe in a new tab.'
-            : 'Click “Start instant checkout” to launch a secure Stripe checkout. We’ll also highlight the quick pay portal in case you need it.';
+            ? 'Click “Start instant checkout” to queue the quick pay portal and open Stripe in a new tab. We’ll prefill the deposit for you.'
+            : 'Click “Start instant checkout” to launch a secure Stripe checkout. We’ll also highlight the quick pay portal with the deposit prefilled in case you need it.';
         } else {
           helperEl.textContent = 'Use the quick pay portal below and enter the amount shown to finish booking.';
         }
@@ -529,6 +685,5 @@
     initServicePicker(serviceData);
   })();
   </script>
-  <script async src="https://js.stripe.com/v3/buy-button.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1161,7 +1161,19 @@ body.experience-security .menu-toggle span{ background:#9fe8f5; }
 .deposit-callout{ font-weight:600; color:#ffb547; font-size:16px; }
 .payment-card.quick-pay{ align-items:center; text-align:center; gap:16px; position:relative; transition: box-shadow .3s ease, transform .3s ease; }
 .quick-pay__copy{ display:flex; flex-direction:column; gap:6px; align-items:center; text-align:center; }
-.payment-card.quick-pay stripe-buy-button{ align-self:center; width:100%; max-width:320px; }
+.quick-pay__form{ display:flex; flex-direction:column; gap:12px; align-self:stretch; width:100%; max-width:320px; }
+.quick-pay__field{ display:flex; flex-direction:column; gap:6px; text-align:left; }
+.quick-pay__field label{ font-size:14px; color:#cbd4d0; }
+.quick-pay__input-wrapper{ display:flex; align-items:center; gap:8px; padding:10px 14px; border-radius:10px; border:1px solid rgba(255,255,255,.18); background:#0f1217; color:#e8ecec; transition:border .2s ease, box-shadow .2s ease; }
+.quick-pay__input-wrapper:focus-within{ border-color:#ffb547; box-shadow:0 0 0 2px rgba(255,181,71,.25); }
+.quick-pay__input-wrapper span{ font-weight:600; color:#ffb547; }
+.quick-pay__input{ flex:1; background:transparent; border:none; color:inherit; font-size:18px; line-height:1.4; }
+.quick-pay__input:focus{ outline:none; }
+.quick-pay__selection{ font-size:14px; color:#cbd4d0; }
+.quick-pay__selection span{ font-weight:600; color:#ffe0b0; }
+.quick-pay__actions{ display:flex; flex-direction:column; gap:6px; }
+.quick-pay__error{ min-height:18px; color:#ffb8b8; }
+.payment-card.quick-pay .btn.is-loading{ opacity:.7; }
 .quick-pay-note{ margin:0; font-size:15px; line-height:1.6; color:#dbe7e4; }
 .payment-card.quick-pay.is-active{ box-shadow:0 0 0 3px rgba(255,181,71,.35), 0 18px 42px rgba(0,0,0,.45); transform:translateY(-2px); }
 .payment-card.quick-pay.is-active .quick-pay-note{ color:#fff4dc; }


### PR DESCRIPTION
## Summary
- replace the embedded Stripe buy button with a quick pay form that can prefill deposits from the service picker
- update the payment page script to sync the quick pay portal amount, submit through the checkout API, and share clearer helper messaging
- style the new quick pay amount input, service label, and loading state to match the page design

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d941a24b108321bc886b3d80a03250