### PR TITLE
Restore inline Stripe card checkout

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -94,7 +94,8 @@
                     step="0.01"
                     min="1"
                     required
-                    aria-describedby="quickPayError quickPayHelper"
+                    aria-describedby="quickPayError quickPayHelper quickPayStatus"
+                    autocomplete="off"
                   />
                 </div>
                 <p class="mini" id="quickPayHelper">You can adjust the amount before continuing if needed.</p>
@@ -102,8 +103,47 @@
               <div class="quick-pay__selection" id="quickPaySelection" hidden>
                 Paying for <span id="quickPayServiceName"></span>
               </div>
+              <div class="quick-pay__field">
+                <label for="quickPayName">Cardholder name</label>
+                <div class="quick-pay__input-wrapper">
+                  <input
+                    type="text"
+                    id="quickPayName"
+                    name="name"
+                    class="quick-pay__input"
+                    autocomplete="cc-name"
+                    inputmode="text"
+                    spellcheck="false"
+                  />
+                </div>
+              </div>
+              <div class="quick-pay__field">
+                <label for="quickPayEmail">Email for receipt (optional)</label>
+                <div class="quick-pay__input-wrapper">
+                  <input
+                    type="email"
+                    id="quickPayEmail"
+                    name="email"
+                    class="quick-pay__input"
+                    autocomplete="email"
+                    inputmode="email"
+                  />
+                </div>
+              </div>
+              <div class="quick-pay__field quick-pay__field--card">
+                <label for="quickPayCardElement">Card details</label>
+                <div
+                  id="quickPayCardElement"
+                  class="quick-pay__card-element"
+                  role="group"
+                  aria-label="Card details"
+                  aria-describedby="quickPayCardErrors quickPayStatus"
+                ></div>
+                <p class="mini quick-pay__error" id="quickPayCardErrors" role="alert" aria-live="polite"></p>
+              </div>
               <div class="quick-pay__actions">
                 <button type="submit" class="btn btn-jeton" id="quickPaySubmit">Buy</button>
+                <p class="mini quick-pay__status" id="quickPayStatus" role="status" aria-live="polite"></p>
                 <p class="mini quick-pay__error" id="quickPayError" role="alert"></p>
               </div>
             </form>
@@ -147,6 +187,7 @@
   <script>
   const PAYMENT_LINK = '#quickPayPortal';
   const CHECKOUT_ENDPOINT = '/api/checkout';
+  const PAYMENT_INTENT_ENDPOINT = '/api/create-payment-intent';
   const stripePublishableKeyMeta = document.querySelector('meta[name="stripe-publishable-key"]');
   let STRIPE_PUBLISHABLE_KEY = stripePublishableKeyMeta?.content?.trim() || '';
   const SERVICE_SNAPSHOT = Object.freeze({
@@ -232,15 +273,23 @@
   const quickPayAmountInput = document.getElementById('quickPayAmount');
   const quickPaySubmitButton = document.getElementById('quickPaySubmit');
   const quickPayErrorEl = document.getElementById('quickPayError');
+  const quickPayStatusEl = document.getElementById('quickPayStatus');
+  const quickPayCardElementContainer = document.getElementById('quickPayCardElement');
+  const quickPayCardErrorEl = document.getElementById('quickPayCardErrors');
   const quickPaySelection = document.getElementById('quickPaySelection');
   const quickPayServiceNameEl = document.getElementById('quickPayServiceName');
   const quickPayHelper = document.getElementById('quickPayHelper');
+  const quickPayNameInput = document.getElementById('quickPayName');
+  const quickPayEmailInput = document.getElementById('quickPayEmail');
   const serviceLinkButton = document.getElementById('serviceLink');
   const helperTextEl = document.getElementById('serviceHelperText');
   const defaultServiceButtonLabel = serviceLinkButton ? serviceLinkButton.textContent.trim() : '';
   const defaultQuickPayButtonLabel = quickPaySubmitButton ? quickPaySubmitButton.textContent.trim() : '';
   let quickPayHighlightTimer;
   let stripeClient = null;
+  let stripeElements = null;
+  let cardElement = null;
+  let cardElementReadyPromise = null;
   let checkoutInFlight = false;
 
   function setFallbackLinks(url) {
@@ -319,7 +368,7 @@
   function setQuickPayButtonLoading(isLoading) {
     if (!quickPaySubmitButton) return;
     if (isLoading) {
-      quickPaySubmitButton.textContent = 'Redirecting…';
+      quickPaySubmitButton.textContent = 'Processing…';
       quickPaySubmitButton.setAttribute('aria-busy', 'true');
       quickPaySubmitButton.classList.add('is-loading');
       quickPaySubmitButton.disabled = true;
@@ -340,6 +389,24 @@
   function reportQuickPayError(message) {
     if (quickPayErrorEl) {
       quickPayErrorEl.textContent = message || '';
+    }
+    if (message) {
+      reportQuickPayStatus('');
+    }
+  }
+
+  function reportQuickPayStatus(message) {
+    if (quickPayStatusEl) {
+      quickPayStatusEl.textContent = message || '';
+    }
+  }
+
+  function reportQuickPayCardError(message) {
+    if (quickPayCardErrorEl) {
+      quickPayCardErrorEl.textContent = message || '';
+    }
+    if (message) {
+      reportQuickPayStatus('');
     }
   }
 
@@ -395,6 +462,67 @@
       console.error('Failed to initialise Stripe.js', error);
       return null;
     }
+  }
+
+  async function ensureCardElement() {
+    if (cardElement) return cardElement;
+    if (!quickPayCardElementContainer) return null;
+
+    if (cardElementReadyPromise) {
+      return cardElementReadyPromise;
+    }
+
+    cardElementReadyPromise = (async () => {
+      try {
+        const stripe = await ensureStripeClient();
+        if (!stripe) return null;
+
+        if (!stripeElements) {
+          stripeElements = stripe.elements({
+            appearance: {
+              theme: 'night',
+              variables: {
+                colorPrimary: '#ffb547',
+                colorText: '#e8ecec',
+                colorTextPlaceholder: '#9aa5a1',
+                colorDanger: '#ffb8b8',
+                colorBackground: '#0f1217',
+                borderRadius: '10px'
+              }
+            }
+          });
+        }
+
+        const element = stripeElements.create('card', {
+          style: {
+            base: {
+              color: '#e8ecec',
+              fontFamily: '"Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+              fontSize: '16px',
+              '::placeholder': { color: '#9aa5a1' }
+            },
+            invalid: {
+              color: '#ffb8b8'
+            }
+          }
+        });
+        element.mount(quickPayCardElementContainer);
+        element.on('change', (event) => {
+          reportQuickPayCardError(event.error?.message || '');
+        });
+
+        return element;
+      } catch (error) {
+        console.error('Failed to initialise Stripe card element', error);
+        return null;
+      }
+    })();
+
+    cardElement = await cardElementReadyPromise;
+    if (!cardElement) {
+      cardElementReadyPromise = null;
+    }
+    return cardElement;
   }
 
   async function launchServiceCheckout({ amount, serviceName }) {
@@ -513,6 +641,11 @@
 
     if (hasAmount) {
       reportQuickPayError('');
+      reportQuickPayCardError('');
+    }
+
+    if (quickPayCardElementContainer) {
+      ensureCardElement();
     }
 
     return paymentUrl;
@@ -557,6 +690,12 @@
       const rawAmount = quickPayAmountInput.value || '';
       const amount = parseFloat(rawAmount);
       const serviceName = quickPayForm.dataset.serviceName || '';
+      const payerName = quickPayNameInput?.value?.trim() || '';
+      const payerEmail = quickPayEmailInput?.value?.trim() || '';
+
+      reportQuickPayError('');
+      reportQuickPayStatus('');
+      reportQuickPayCardError('');
 
       if (Number.isNaN(amount) || amount <= 0) {
         reportQuickPayError('Enter a valid amount above to continue.');
@@ -565,49 +704,91 @@
       }
 
       const stripe = await ensureStripeClient();
-      if (!stripe) {
-        reportQuickPayError('We couldn’t initialise Stripe. Message the studio and we’ll send a direct payment link.');
+      const card = await ensureCardElement();
+      if (!stripe || !card) {
+        reportQuickPayError('The secure card form is unavailable. Use the instant checkout link above while we refresh it.');
         return;
       }
 
       if (checkoutInFlight) return;
       checkoutInFlight = true;
       setQuickPayButtonLoading(true);
-      reportQuickPayError('');
 
       try {
-        const response = await fetch(CHECKOUT_ENDPOINT, {
+        const response = await fetch(PAYMENT_INTENT_ENDPOINT, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            name: `${serviceName || 'Design Project'} Payment`,
             amount,
-            metadata: {
-              service: serviceName || '',
-              source: 'quick-pay-portal'
-            }
+            serviceName,
+            name: payerName,
+            email: payerEmail
           })
         });
 
+        const payload = await response.json().catch(() => ({}));
         if (!response.ok) {
-          throw new Error(`Checkout request failed: ${response.status}`);
+          const serverMessage = typeof payload?.message === 'string' ? payload.message : '';
+          const isClientError = response.status >= 400 && response.status < 500;
+          const message = isClientError && serverMessage
+            ? serverMessage
+            : 'Payment could not be initiated. Try again in a moment.';
+          throw new Error(message);
         }
 
-        const payload = await response.json();
-        if (payload?.url) {
-          window.location.href = payload.url;
+        const clientSecret = payload?.clientSecret;
+        if (!clientSecret) {
+          throw new Error('Missing payment credentials from the server.');
+        }
+
+        const confirmation = await stripe.confirmCardPayment(clientSecret, {
+          payment_method: {
+            card,
+            billing_details: {
+              name: payerName || undefined,
+              email: payerEmail || undefined
+            }
+          }
+        });
+
+        if (confirmation.error) {
+          throw confirmation.error;
+        }
+
+        const status = confirmation.paymentIntent?.status;
+        if (status === 'succeeded') {
+          const successMessage = payerEmail
+            ? 'Payment complete! Check your email for the receipt.'
+            : 'Payment complete! We will follow up with a receipt shortly.';
+          reportQuickPayStatus(successMessage);
+          reportQuickPayCardError('');
+          if (quickPayAmountInput) quickPayAmountInput.value = '';
+          if (quickPayNameInput) quickPayNameInput.value = '';
+          if (quickPayEmailInput) quickPayEmailInput.value = '';
+          if (typeof card.clear === 'function') {
+            card.clear();
+          }
           return;
         }
 
-        if (payload?.id) {
-          const { error } = await stripe.redirectToCheckout({ sessionId: payload.id });
-          if (error) throw error;
-        } else {
-          throw new Error('Missing checkout session data');
+        if (status === 'processing') {
+          reportQuickPayStatus('Payment is processing. We’ll email you as soon as it completes.');
+          reportQuickPayCardError('');
+          return;
         }
+
+        throw new Error('We couldn’t confirm the payment. Try again or message the studio for help.');
       } catch (error) {
         console.error('Quick pay checkout failed', error);
-        reportQuickPayError('We couldn’t open Stripe automatically. Try again or message the studio for help.');
+        if (error?.type === 'card_error') {
+          reportQuickPayCardError(error.message || 'There was a problem with your card details.');
+          reportQuickPayError('Update the card details above and try again.');
+        } else {
+          const message = typeof error?.message === 'string' && error.message.trim()
+            ? error.message
+            : 'We couldn’t confirm the payment. Try again or message the studio for help.';
+          reportQuickPayError(message);
+        }
       } finally {
         checkoutInFlight = false;
         setQuickPayButtonLoading(false);
@@ -841,6 +1022,7 @@
   (async function initPaymentPage() {
     renderServices(SERVICE_SNAPSHOT);
     initServicePicker(SERVICE_SNAPSHOT);
+    await ensureCardElement();
 
     const serviceData = await loadServiceData();
     if (serviceData !== SERVICE_SNAPSHOT) {

--- a/api/create-payment-intent.js
+++ b/api/create-payment-intent.js
@@ -1,0 +1,45 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const { amount, serviceName, name, email } = req.body || {};
+  const numericAmount = Number(amount);
+
+  if (!numericAmount || Number.isNaN(numericAmount) || numericAmount <= 0) {
+    return res.status(400).json({ message: 'A valid amount is required.' });
+  }
+
+  const secret = process.env.STRIPE_SECRET_KEY;
+  if (!secret) {
+    return res.status(500).json({ message: 'Stripe secret key missing. Set STRIPE_SECRET_KEY in Vercel.' });
+  }
+
+  try {
+    const Stripe = (await import('stripe')).default;
+    const stripe = new Stripe(secret, { apiVersion: '2022-11-15' });
+
+    const metadata = {
+      source: 'quick-pay-portal',
+    };
+
+    if (serviceName) metadata.service = serviceName;
+    if (name) metadata.cardholder = name;
+
+    const intent = await stripe.paymentIntents.create({
+      amount: Math.round(numericAmount * 100),
+      currency: 'usd',
+      payment_method_types: ['card'],
+      metadata,
+      receipt_email: email || undefined,
+      description: `${serviceName || 'Design Project'} Payment`,
+      statement_descriptor: 'Omnilon Interiors',
+    });
+
+    return res.status(200).json({ clientSecret: intent.client_secret });
+  } catch (error) {
+    console.error('Stripe error creating PaymentIntent', error);
+    const message = error?.message || 'Stripe error creating PaymentIntent.';
+    return res.status(500).json({ message });
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1169,10 +1169,16 @@ body.experience-security .menu-toggle span{ background:#9fe8f5; }
 .quick-pay__input-wrapper span{ font-weight:600; color:#ffb547; }
 .quick-pay__input{ flex:1; background:transparent; border:none; color:inherit; font-size:18px; line-height:1.4; }
 .quick-pay__input:focus{ outline:none; }
+.quick-pay__field--card{ gap:10px; }
+#quickPayCardElement{ padding:12px 14px; border-radius:10px; border:1px solid rgba(255,255,255,.18); background:#0f1217; min-height:52px; display:flex; align-items:center; transition:border .2s ease, box-shadow .2s ease; }
+#quickPayCardElement.StripeElement--focus{ border-color:#ffb547; box-shadow:0 0 0 2px rgba(255,181,71,.25); }
+#quickPayCardElement.StripeElement--invalid{ border-color:#ffb8b8; box-shadow:0 0 0 2px rgba(255,184,184,.25); }
+#quickPayCardElement.StripeElement--complete{ border-color:rgba(255,255,255,.35); }
 .quick-pay__selection{ font-size:14px; color:#cbd4d0; }
 .quick-pay__selection span{ font-weight:600; color:#ffe0b0; }
 .quick-pay__actions{ display:flex; flex-direction:column; gap:6px; }
 .quick-pay__error{ min-height:18px; color:#ffb8b8; }
+.quick-pay__status{ min-height:18px; color:#c2f1d5; }
 .payment-card.quick-pay .btn.is-loading{ opacity:.7; }
 .quick-pay-note{ margin:0; font-size:15px; line-height:1.6; color:#dbe7e4; }
 .payment-card.quick-pay.is-active{ box-shadow:0 0 0 3px rgba(255,181,71,.35), 0 18px 42px rgba(0,0,0,.45); transform:translateY(-2px); }


### PR DESCRIPTION
## Summary
- add Stripe Elements card fields and status messaging back into the quick pay portal
- create a PaymentIntent API endpoint and update the client flow to confirm payments without leaving the page
- refresh payment styles for the embedded card element to match the booking experience

## Testing
- not run (Stripe integration requires live credentials)


------
https://chatgpt.com/codex/tasks/task_e_68d94fe9fee48321b59a6f8f8595b765