### PR TITLE
Refine mobile payment layout

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -46,7 +46,7 @@
         </div>
 
         <div class="payment-grid">
-          <article class="jeton-card payment-card">
+          <article class="jeton-card payment-card payment-card--selector">
             <h3>Choose your service</h3>
             <p>Select a service to see the full price and the 50% deposit due today.</p>
 
@@ -68,13 +68,15 @@
             </div>
           </article>
 
-          <article class="jeton-card payment-card">
+          <article class="jeton-card payment-card payment-card--checkout">
             <h3>Pay your deposit</h3>
             <p>
               Use our secure Stripe checkout to submit the 50% deposit. We’ll send a confirmation email with next steps
               and a link to the project questionnaire.
             </p>
+            <p class="payment-security">Encrypted checkout powered by Stripe. No card details are stored on our servers.</p>
             <stripe-buy-button
+              class="payment-buy-button"
               buy-button-id="buy_btn_1SByhQ2dSpsiXnOLd7LObOHQ"
               publishable-key="pk_live_51S7wAs2dSpsiXnOLBxKLtF0iAkgXgMr7QMn0TAo9fDIbiJXbfCOwyNzMErUJ5OcIUWityN0FaXjjRh2KyxRBFNNo00RheMkkDi"
             >

--- a/style.css
+++ b/style.css
@@ -1141,8 +1141,18 @@ body.experience-security .menu-toggle span{ background:#9fe8f5; }
 .payment-checklist li span{ font-weight:600; text-transform:uppercase; letter-spacing:.06em; font-size:12px; color:#ffb547; }
 .payment-alert{ padding:16px 18px; border-radius:12px; border:1px solid rgba(255,181,71,.35); background:rgba(255,181,71,.08); font-size:14px; line-height:1.6; }
 .payment-alert a{ color:#ffe0b0; text-decoration:underline; text-decoration-thickness:2px; }
-.payment-grid{ display:grid; gap:18px; grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); }
-.payment-card{ display:flex; flex-direction:column; gap:12px; }
+.payments .jeton-card{ padding:28px; border-radius:20px; background:radial-gradient(140% 120% at 10% 0%, rgba(255,181,71,.18), rgba(11,13,18,.88)); border:1px solid rgba(255,255,255,.09); box-shadow:0 24px 48px rgba(0,0,0,.42); backdrop-filter:blur(18px); }
+.payments .jeton-card h2,.payments .jeton-card h3{ font-family:'Playfair Display',serif; letter-spacing:.01em; }
+.payments .jeton-card p{ color:#d0dad7; line-height:1.6; }
+.payment-grid{ display:grid; gap:22px; grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); align-items:stretch; }
+.payment-card{ display:flex; flex-direction:column; gap:16px; position:relative; isolation:isolate; z-index:0; }
+.payment-card::after{ content:""; position:absolute; inset:0; border-radius:18px; border:1px solid rgba(255,255,255,.06); pointer-events:none; mix-blend-mode:screen; opacity:.35; z-index:-1; }
+.payment-card--selector .service-picker,.payment-card--selector .service-details{ width:100%; }
+.payment-card--selector .service-details{ margin-top:4px; }
+.payment-card--checkout{ align-items:center; text-align:center; gap:18px; }
+.payment-card--checkout p{ max-width:38ch; }
+.payment-security{ font-size:13px; text-transform:uppercase; letter-spacing:.08em; color:#ffe0b0; background:rgba(255,181,71,.12); border:1px solid rgba(255,181,71,.35); border-radius:999px; padding:10px 18px; align-self:center; box-shadow:0 8px 22px rgba(255,181,71,.18); }
+.payment-buy-button{ display:block; width:100%; max-width:320px; margin:6px auto 0; }
 .pay-form label{ display:block; font-size:14px; margin-top:10px; margin-bottom:4px; color:#cbd4d0; }
 .pay-form input{ width:100%; margin-bottom:6px; padding:10px 12px; border-radius:8px; border:1px solid rgba(255,255,255,.18); background:#0f1217; color:#e8ecec; transition:border .2s ease, box-shadow .2s ease; }
 .pay-form input:focus{ outline:none; border-color:#ffb547; box-shadow:0 0 0 2px rgba(255,181,71,.25); }
@@ -1219,7 +1229,15 @@ body.experience-security .menu-toggle span{ background:#9fe8f5; }
 
 @media(max-width:720px){
   .payment-checklist{ grid-template-columns:1fr; }
-  .payment-grid,.payment-support-grid{ grid-template-columns:1fr; }
+  .payments{ align-items:center; }
+  .payment-overview{ text-align:center; max-width:560px; }
+  .payment-overview .mini{ margin-left:auto; margin-right:auto; }
+  .payment-grid,.payment-support-grid{ grid-template-columns:1fr; width:100%; justify-items:center; }
+  .payment-grid .payment-card{ width:min(100%, 360px); }
+  .payment-card--selector h3,.payment-card--selector > p,.payment-card--checkout h3,.payment-card--checkout > p{ text-align:center; }
+  .payment-card--selector .service-picker,.payment-card--selector .service-details{ text-align:left; }
+  .payment-card--checkout{ width:min(100%, 360px); }
+  .payment-security{ font-size:12px; }
   .brief-grid{ grid-template-columns:1fr; }
   .summary-actions{ flex-direction:column; }
 }


### PR DESCRIPTION
## Summary
- center the payment cards on small screens and align the overview copy for mobile
- refresh the payment card styling with gradients, borders, and spacing tuned to the Ømnilon aesthetic
- add a secure checkout note and Stripe button alignment to reinforce trust on the payment screen

## Testing
- _No automated tests were run (static HTML/CSS updates only)_

------
https://chatgpt.com/codex/tasks/task_e_68d954ed4e4c8321a7743cce6e40974c