### PR TITLE
Update interiors testimonial imagery

### DIFF
--- a/data/testimonials.json
+++ b/data/testimonials.json
@@ -3,7 +3,8 @@
     "quote": "Absolutely transformed our living room. Calm, warm, and practical.",
     "name": "A. Rivera",
     "role": "Homeowner",
-    "avatar": "https://images.unsplash.com/photo-1544725176-7c40e5a2c9f9?q=80&w=256&auto=format&fit=crop"
+    "avatar": "images/slide3.jpg",
+    "avatarAlt": "Styled living room with layered textiles"
   },
   {
     "quote": "Clear milestones and great communication. Install day felt effortless.",

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
                                 <span class="sr-only">Rated 5 out of 5</span>
                                 <p class="t-quote">Absolutely transformed our living room. Calm, warm, and practical.</p>
                                 <div class="t-meta">
-                                    <img class="t-avatar" src="https://images.unsplash.com/photo-1544725176-7c40e5a2c9f9?q=80&w=256&auto=format&fit=crop" alt="Portrait of A. Rivera" loading="lazy" />
+                                    <img class="t-avatar" src="images/slide3.jpg" alt="Styled living room with layered textiles" loading="lazy" />
                                     <div>
                                         <strong>A. Rivera</strong>
                                         <span class="t-role">Homeowner</span>

--- a/script.js
+++ b/script.js
@@ -257,20 +257,24 @@ document.addEventListener('DOMContentLoaded', async () => {
   const track = document.getElementById('testimonialTrack');
   if (!track) return;
 
-  const template = (t) => `
-    <article class="t-card fx-rise">
-      <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
-      <span class="sr-only">Rated 5 out of 5</span>
-      <p class="t-quote">${t.quote}</p>
-      <div class="t-meta">
-        <img class="t-avatar" src="${t.avatar}" alt="Portrait of ${t.name}" loading="lazy" />
-        <div>
-          <strong>${t.name}</strong>
-          <span class="t-role">${t.role || ''}</span>
+  const template = (t) => {
+    const alt = t.avatarAlt || `Portrait of ${t.name}`;
+    return `
+      <article class="t-card fx-rise">
+        <div class="t-stars" aria-hidden="true"><span>★★★★★</span></div>
+        <span class="sr-only">Rated 5 out of 5</span>
+        <p class="t-quote">${t.quote}</p>
+        <div class="t-meta">
+          <img class="t-avatar" src="${t.avatar}" alt="${alt}" loading="lazy" />
+          <div>
+            <strong>${t.name}</strong>
+            <span class="t-role">${t.role || ''}</span>
+          </div>
         </div>
       </div>
     </article>
-  `;
+    `;
+  };
 
   const src = track.dataset.src;
   if (src) {


### PR DESCRIPTION
## Summary
- replace the Ømnilon Interiors testimonial avatar with an on-brand interiors photo
- allow testimonials to supply custom alt text for avatar images
- set the first testimonial to use a local interiors image and descriptive alt text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff5711e188321b4c77cbbe6c8f161