### PR TITLE
Add Ømnilon Ink experience and tattoo booking flow

### DIFF
--- a/images/airpods-pro-reference.svg
+++ b/images/airpods-pro-reference.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="220" viewBox="0 0 420 220" role="img" aria-labelledby="title desc">
+  <title id="title">AirPods Pro case reference next to ruler</title>
+  <desc id="desc">Illustration of an AirPods Pro case silhouette beside a ruler with inch markings to show flash tattoo sizing.</desc>
+  <defs>
+    <linearGradient id="caseGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#e8fff3"/>
+      <stop offset="100%" stop-color="#b6f0d5"/>
+    </linearGradient>
+    <linearGradient id="rulerGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f4f6f8"/>
+      <stop offset="100%" stop-color="#d5dae0"/>
+    </linearGradient>
+  </defs>
+  <rect width="420" height="220" rx="24" fill="#06140c"/>
+  <g transform="translate(36 36)">
+    <rect x="18" y="16" width="220" height="140" rx="60" fill="url(#caseGradient)" stroke="#8cebbf" stroke-width="4"/>
+    <rect x="98" y="24" width="60" height="12" rx="6" fill="#c7f5dd"/>
+    <circle cx="128" cy="102" r="10" fill="#90e7c0"/>
+    <rect x="300" y="0" width="20" height="180" rx="6" fill="url(#rulerGradient)" stroke="#c0c6cf" stroke-width="2"/>
+    <g stroke="#7a808a" stroke-width="2">
+      <line x1="300" y1="20" x2="320" y2="20"/>
+      <line x1="300" y1="40" x2="320" y2="40"/>
+      <line x1="300" y1="60" x2="320" y2="60"/>
+      <line x1="300" y1="80" x2="320" y2="80"/>
+      <line x1="300" y1="100" x2="320" y2="100"/>
+      <line x1="300" y1="120" x2="320" y2="120"/>
+      <line x1="300" y1="140" x2="320" y2="140"/>
+      <line x1="300" y1="160" x2="320" y2="160"/>
+    </g>
+    <g stroke="#4abf8f" stroke-width="3">
+      <line x1="300" y1="0" x2="320" y2="0"/>
+      <line x1="300" y1="180" x2="320" y2="180"/>
+    </g>
+    <text x="128" y="180" fill="#c8f3dd" font-family="'Inter', Arial, sans-serif" font-size="18" text-anchor="middle">~ 2.39" x 1.78" (AirPods Pro case)</text>
+    <text x="310" y="204" fill="#9fc0aa" font-family="'Inter', Arial, sans-serif" font-size="15" text-anchor="middle">Inches</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <div class="selector-inner reveal fx-rise">
             <span class="selector-badge">ØMNILON</span>
             <h1 id="experienceTitle">Select your experience</h1>
-            <p class="selector-copy">One house, two disciplines. Choose interiors for calm spatial design, or security to uncover profit-eating vulnerabilities with our Secret Lifters.</p>
+            <p class="selector-copy">One house, three disciplines. Choose interiors for calm spatial design, security intelligence to uncover vulnerabilities, or ink to plan your next tattoo session.</p>
             <div class="selector-grid">
                 <button class="selector-card" data-target="interiors">
                     <span class="selector-heading">Ømnilon Interiors</span>
@@ -29,6 +29,11 @@
                     <span class="selector-heading">Ømnilon Security</span>
                     <span class="selector-text">Our new asset protection intelligence unit. Secret Lifters simulate organized theft—online and in-store—so you can close the gaps first.</span>
                     <span class="selector-cta">Deploy a Secret Lifter</span>
+                </button>
+                <button class="selector-card" data-target="ink">
+                    <span class="selector-heading">Ømnilon Ink</span>
+                    <span class="selector-text">Flash tattoos, custom line work, and apprentice-friendly pricing with transparent deposits and a clear waiver.</span>
+                    <span class="selector-cta">Book a tattoo session</span>
                 </button>
             </div>
         </div>
@@ -48,6 +53,7 @@
                     <span class="brand-title">ØMNILON</span>
                 </a>
                 <div class="header-actions">
+                    <button class="experience-pill" data-switch-experience="ink">Book Ømnilon Ink</button>
                     <button class="experience-pill" data-switch-experience="security">Explore Security</button>
                     <button id="menuToggle" class="menu-toggle" data-menu-toggle="siteNav" data-menu-class="nav-open" aria-label="Open menu" aria-expanded="false" aria-controls="siteNav">
                         <span></span><span></span><span></span>
@@ -236,6 +242,7 @@
                 </a>
                 <div class="header-actions">
                     <button class="experience-pill" data-switch-experience="interiors">Return to Interiors</button>
+                    <button class="experience-pill" data-switch-experience="ink">Book Ømnilon Ink</button>
                     <button id="securityMenuToggle" class="menu-toggle" data-menu-toggle="securityNav" data-menu-class="nav-open-security" aria-label="Open menu" aria-expanded="false" aria-controls="securityNav">
                         <span></span><span></span><span></span>
                     </button>
@@ -406,6 +413,183 @@
         </div>
         <footer class="site-footer">
             <p>&copy; 2025 Ømnilon Security — Asset Protection Intelligence</p>
+        </footer>
+    </div>
+
+    <div id="inkExperience" class="experience experience-ink" hidden aria-hidden="true">
+        <div class="wrapper">
+            <header class="brand-header reveal fade">
+                <a href="#ink-home" class="brand" aria-label="Ømnilon Ink">
+                    <span class="brand-title">ØMNILON</span>
+                </a>
+                <div class="header-actions">
+                    <button class="experience-pill" data-switch-experience="interiors">Return to Interiors</button>
+                    <button class="experience-pill" data-switch-experience="security">Explore Security</button>
+                    <button id="inkMenuToggle" class="menu-toggle" data-menu-toggle="inkNav" data-menu-class="nav-open-ink" aria-label="Open menu" aria-expanded="false" aria-controls="inkNav">
+                        <span></span><span></span><span></span>
+                    </button>
+                </div>
+            </header>
+            <nav id="inkNav">
+                <a href="#ink-home" class="active">Overview</a>
+                <a href="#ink-flash">Flash Specials</a>
+                <a href="#ink-pricing">Pricing</a>
+                <a href="#ink-waiver">Waiver</a>
+                <a href="#ink-booking">Book</a>
+            </nav>
+
+            <main class="onepage">
+                <section id="ink-home" class="hero hero-ink reveal fx-clip" style="position:relative;">
+                    <div class="bg-grid"></div>
+                    <div class="orb orb-1" data-parallax-y="0.05"></div>
+                    <div class="orb orb-2" data-parallax-y="0.09"></div>
+                    <div class="hero-inner fx-rise" data-parallax="0.12">
+                        <h1 class="grad-text">Intentional tattoos with apprentice-accessible pricing.</h1>
+                        <p>Ømnilon Ink is the home for my tattoo apprenticeship—meaning you receive fresh flash, thoughtful placement, and transparent pricing while I continue to hone my craft.</p>
+                        <div class="cta-row">
+                            <a class="btn btn-jeton" href="#ink-booking">Request a session</a>
+                            <a class="btn btn-outline" href="#ink-flash">Browse flash specials</a>
+                        </div>
+                    </div>
+                    <div class="mock-window reveal from-right" aria-hidden="true">
+                        <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?q=80&w=1600&auto=format&fit=crop" alt="Tattoo artist working on a client's arm" loading="lazy" />
+                    </div>
+                    <a class="scroll-cue" href="#ink-flash" aria-label="Scroll to flash specials"></a>
+                </section>
+
+                <section id="ink-flash" class="section feature-grid stagger features-ink" data-stagger-step="0.08">
+                    <article class="feature ink-card fx-rise">
+                        <h3>Flash queue</h3>
+                        <p>Curated, ready-to-go flash sheets refreshed every month. Simple line work and micro pieces stay at apprentice pricing.</p>
+                    </article>
+                    <article class="feature ink-card fx-rise">
+                        <h3>Sticker discount</h3>
+                        <p>Bring any sticker to the appointment and your flash piece drops from $39.99 to $29.99—my thanks for supporting the journey.</p>
+                    </article>
+                    <article class="feature ink-card fx-rise">
+                        <h3>Thoughtful placements</h3>
+                        <p>We’ll map tattoos using real-world objects so you know exactly what fits comfortably and heals clean.</p>
+                    </article>
+                    <article class="feature ink-card fx-rise">
+                        <h3>Aftercare guidance</h3>
+                        <p>Every session includes a custom aftercare PDF, healing check-ins, and product suggestions.</p>
+                    </article>
+                </section>
+
+                <section id="ink-pricing" class="section ink-pricing reveal">
+                    <div class="ink-pricing-intro fx-rise">
+                        <h2>Transparent pricing & deposits</h2>
+                        <p>Flash tattoos are $39.99—or $29.99 when you bring me a sticker. Larger or more complex tattoos scale from $59.99 to $499.99 depending on coverage, detail, and placement. Every appointment requires a 50% deposit that goes toward your final total.</p>
+                    </div>
+                    <div class="ink-pricing-grid">
+                        <article class="ink-price-card fx-rise">
+                            <h3>Flash tier</h3>
+                            <p>Anything the size of an AirPods Pro case or smaller. Perfect for line work, minis, or script.</p>
+                            <ul>
+                                <li>$39.99 standard rate</li>
+                                <li>$29.99 with sticker discount</li>
+                                <li>30–45 minute seat time</li>
+                            </ul>
+                        </article>
+                        <article class="ink-price-card fx-rise">
+                            <h3>Custom tier</h3>
+                            <p>Pieces larger than the flash tier or with shading, color, or complex line work.</p>
+                            <ul>
+                                <li>$59.99–$199.99 for palm-sized work</li>
+                                <li>$199.99–$499.99 for multi-session or highly detailed pieces</li>
+                                <li>Priced collaboratively after consult</li>
+                            </ul>
+                        </article>
+                        <article class="ink-price-card fx-rise">
+                            <h3>Deposits</h3>
+                            <p>All bookings require a 50% deposit to reserve the slot. Deposits are non-refundable but transferable once with 48 hours’ notice.</p>
+                            <ul>
+                                <li>Applied directly to your final balance</li>
+                                <li>Secure online payment link provided after consult</li>
+                                <li>Reschedules beyond one incur a new deposit</li>
+                            </ul>
+                        </article>
+                    </div>
+                </section>
+
+                <section id="ink-waiver" class="section ink-waiver reveal">
+                    <div class="ink-waiver-copy fx-rise">
+                        <h2>Waiver & apprentice transparency</h2>
+                        <p>Please review this waiver before booking. Agreeing affirms that you understand my current apprenticeship status and the pricing advantages it provides.</p>
+                        <ul>
+                            <li>You acknowledge Ømnilon Ink operates under an apprenticeship; discounted pricing reflects this stage of practice.</li>
+                            <li>You consent to receive a tattoo from an apprentice and understand I may decline designs beyond my present abilities.</li>
+                            <li>You release Ømnilon Ink and affiliated parties from liability for adverse reactions, including allergic responses, infections, or healing complications.</li>
+                            <li>You confirm you are 18+ (or have the legally required documentation) and are not under the influence of drugs or alcohol.</li>
+                            <li>You agree to follow aftercare instructions provided during your appointment.</li>
+                        </ul>
+                        <p class="ink-size-note">We’ll size each tattoo using real-life objects for clarity. <a href="images/airpods-pro-reference.svg" target="_blank" rel="noopener">See the AirPods Pro case size reference</a>—anything at or below that footprint stays in the flash tier. Larger pieces will be priced collaboratively based on complexity.</p>
+                    </div>
+                </section>
+
+                <section id="ink-booking" class="section contact-form reveal ink-booking">
+                    <h2>Request your Ømnilon Ink session</h2>
+                    <form id="inkBookingForm" data-contact-form data-experience="ink">
+                        <label for="inkName">Name:</label>
+                        <input type="text" id="inkName" name="name" required>
+
+                        <label for="inkEmail">Email:</label>
+                        <input type="email" id="inkEmail" name="email" required>
+
+                        <label for="inkPhone">Phone (optional):</label>
+                        <input type="tel" id="inkPhone" name="phone" placeholder="For quick confirmations">
+
+                        <label for="inkPlacement">Desired placement:</label>
+                        <input type="text" id="inkPlacement" name="placement" placeholder="Forearm, calf, ankle, etc." required>
+
+                        <label for="inkSize">Estimated size:</label>
+                        <select id="inkSize" name="size" required>
+                            <option value="AirPods-case-or-smaller">AirPods Pro case or smaller (flash tier)</option>
+                            <option value="Sticker-discount">Flash tier with sticker discount</option>
+                            <option value="Palm-sized">Palm-sized (approx 2"–4")</option>
+                            <option value="Half-sheet">Half-sheet or multiple elements</option>
+                            <option value="Large-scale">Larger or multi-session concept</option>
+                        </select>
+
+                        <label for="inkIdea">Tell me about the artwork:</label>
+                        <textarea id="inkIdea" name="idea" placeholder="Share flash number or describe your custom concept." required></textarea>
+
+                        <label for="inkAvailability">Preferred days/times:</label>
+                        <input type="text" id="inkAvailability" name="availability" placeholder="e.g., Weeknights after 6pm or Sundays">
+
+                        <div class="ink-consent-group">
+                            <label class="ink-checkbox">
+                                <input type="checkbox" name="sticker" value="yes">
+                                I’m bringing a sticker for the flash discount ($10 off flash tier).
+                            </label>
+                            <label class="ink-checkbox">
+                                <input type="checkbox" name="deposit" value="agree" required>
+                                I understand a 50% deposit is required to hold my appointment and will be applied to the total.
+                            </label>
+                            <label class="ink-checkbox">
+                                <input type="checkbox" name="waiver" value="agree" required>
+                                I have read the waiver above, acknowledge the apprenticeship status, and consent to proceed.
+                            </label>
+                        </div>
+
+                        <button type="submit" class="btn btn-jeton">Submit request</button>
+                    </form>
+                    <p class="form-status" data-form-status aria-live="polite" role="status"></p>
+                    <div class="ink-meta fx-rise">
+                        <h3>Studio details</h3>
+                        <ul class="contact-meta">
+                            <li>Email: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
+                            <li>Text line: <a href="tel:4049198026">404-919-8026</a></li>
+                            <li>Studio: Atlanta, GA (exact address provided after booking)</li>
+                            <li>Follow apprentice progress: <a href="https://www.instagram.com/" target="_blank" rel="noopener">Instagram updates</a></li>
+                        </ul>
+                        <p class="ink-prep">Please arrive sober, well rested, and hydrated. Wear clothing that gives easy access to the placement area, and eat within two hours of your appointment.</p>
+                    </div>
+                </section>
+            </main>
+        </div>
+        <footer class="site-footer">
+            <p>&copy; 2025 Ømnilon Ink — Tattoo Apprenticeship Studio</p>
         </footer>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -397,14 +397,28 @@ document.addEventListener('DOMContentLoaded', () => {
 // Experience selector + multi-nav toggle handling
 document.addEventListener('DOMContentLoaded', () => {
     const selector = document.getElementById('experienceSelector');
-    const experiences = {
-        interiors: document.getElementById('interiorsExperience'),
-        security: document.getElementById('securityExperience')
+    const experienceConfig = {
+        interiors: {
+            wrapper: document.getElementById('interiorsExperience'),
+            navId: 'siteNav',
+            bodyClass: 'experience-interiors'
+        },
+        security: {
+            wrapper: document.getElementById('securityExperience'),
+            navId: 'securityNav',
+            bodyClass: 'experience-security'
+        },
+        ink: {
+            wrapper: document.getElementById('inkExperience'),
+            navId: 'inkNav',
+            bodyClass: 'experience-ink'
+        }
     };
+    const experiences = Object.fromEntries(Object.entries(experienceConfig).map(([name, config]) => [name, config.wrapper]));
     const toggles = Array.from(document.querySelectorAll('[data-menu-toggle]'));
 
     const closeNavs = () => {
-        ['nav-open', 'nav-open-security'].forEach(cls => document.body.classList.remove(cls));
+        ['nav-open', 'nav-open-security', 'nav-open-ink'].forEach(cls => document.body.classList.remove(cls));
         toggles.forEach(btn => btn.setAttribute('aria-expanded', 'false'));
     };
 
@@ -437,14 +451,21 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const activateExperience = (name) => {
-        if (!experiences[name]) return;
+        const config = experienceConfig[name];
+        if (!config || !config.wrapper) return;
         setExperienceVisibility(name);
         document.body.classList.add('experience-active');
-        document.body.classList.remove('experience-interiors', 'experience-security');
-        document.body.classList.add(name === 'security' ? 'experience-security' : 'experience-interiors');
+        Object.values(experienceConfig).forEach(cfg => {
+            if (cfg.bodyClass) {
+                document.body.classList.remove(cfg.bodyClass);
+            }
+        });
+        if (config.bodyClass) {
+            document.body.classList.add(config.bodyClass);
+        }
         document.body.dataset.experience = name;
         document.querySelectorAll('nav a').forEach(link => link.classList.remove('active'));
-        const navEl = document.getElementById(name === 'security' ? 'securityNav' : 'siteNav');
+        const navEl = config.navId ? document.getElementById(config.navId) : null;
         const firstLink = navEl ? navEl.querySelector('a[href^="#"]') : null;
         if (firstLink) firstLink.classList.add('active');
         closeNavs();
@@ -483,6 +504,8 @@ document.addEventListener('DOMContentLoaded', () => {
         initial = requested;
     } else if (/^#security-/.test(hash)) {
         initial = 'security';
+    } else if (/^#ink-/.test(hash)) {
+        initial = 'ink';
     } else if (/^#(home|services|portfolio|about|contact)/i.test(hash)) {
         initial = 'interiors';
     }

--- a/style.css
+++ b/style.css
@@ -802,11 +802,21 @@ body {
 body.experience-interiors .experience-pill[data-switch-experience="security"] {
     background: rgba(255, 255, 255, 0.02);
 }
+body.experience-interiors .experience-pill[data-switch-experience="ink"] {
+    background: rgba(100, 245, 179, 0.16);
+    border-color: rgba(100, 245, 179, 0.28);
+    color: #e6fff2;
+}
 
 body.experience-security .experience-pill[data-switch-experience="interiors"] {
     background: rgba(82, 196, 211, 0.14);
     border-color: rgba(82, 196, 211, 0.36);
     color: #dff7ff;
+}
+body.experience-security .experience-pill[data-switch-experience="ink"] {
+    background: rgba(100, 245, 179, 0.18);
+    border-color: rgba(100, 245, 179, 0.32);
+    color: #e5fff2;
 }
 
 body.experience-security #scrollProgress {
@@ -975,6 +985,76 @@ body.experience-security #scrollProgress {
 #securityExperience .contact-meta a:hover,
 #securityExperience .contact-meta a:focus-visible { color: #9af0ff; }
 
+#inkExperience nav { background-color: rgba(9, 24, 16, 0.88); border: 1px solid rgba(91, 240, 170, 0.24); box-shadow: 0 18px 48px rgba(5, 18, 12, 0.5); }
+#inkExperience nav a { color: #e9fff4; }
+#inkExperience nav a:hover,
+#inkExperience nav a.active { background: linear-gradient(90deg, #68f7ba, #32d789); color: #042b1b; }
+
+#inkExperience .brand { color: #e5fff2; }
+#inkExperience .brand-title { background: linear-gradient(90deg, #68f7ba, #bdfedb); -webkit-background-clip: text; background-clip: text; color: transparent; }
+#inkExperience .grad-text { background: linear-gradient(92deg, #f4fff7 0%, #c1ffd8 40%, #4fe4a2 88%); -webkit-background-clip: text; background-clip: text; color: transparent; }
+
+.hero-ink { background: radial-gradient(900px 480px at -10% -20%, rgba(61, 214, 137, 0.35), transparent 60%), radial-gradient(820px 520px at 110% 0%, rgba(56, 239, 170, 0.18), transparent 58%), linear-gradient(180deg, #07120c, #0c1a12); box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05); }
+.hero-ink .orb-1 { background: radial-gradient(circle at 28% 28%, rgba(104, 247, 186, 0.42), transparent 70%); }
+.hero-ink .orb-2 { background: radial-gradient(circle at 60% 38%, rgba(50, 215, 137, 0.32), transparent 65%); }
+
+#inkExperience .btn.btn-jeton { border: none; color: #04291c; background: linear-gradient(90deg, #64f5b3, #2ddc8d); box-shadow: 0 10px 32px rgba(41, 220, 141, 0.28); }
+#inkExperience .btn.btn-outline { border: 1px solid rgba(123, 238, 183, 0.45); color: #dfffee; }
+
+.features-ink .ink-card { background: rgba(7, 20, 14, 0.86); border: 1px solid rgba(88, 236, 169, 0.22); border-radius: 18px; padding: clamp(18px, 3vw, 26px); box-shadow: 0 18px 48px rgba(4, 18, 12, 0.45); }
+.features-ink .ink-card h3 { color: #e9fff4; }
+.features-ink .ink-card p { color: #b9eacc; }
+
+.ink-pricing { text-align: center; }
+.ink-pricing-intro { max-width: 820px; margin: 0 auto 32px; }
+.ink-pricing-intro p { color: #b9eacc; }
+.ink-pricing-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: clamp(18px, 3vw, 24px); }
+.ink-price-card { background: rgba(7, 22, 14, 0.9); border: 1px solid rgba(95, 244, 174, 0.24); border-radius: 20px; padding: clamp(20px, 3vw, 28px); box-shadow: 0 20px 54px rgba(3, 15, 9, 0.48); text-align: left; color: #daf7e7; display: flex; flex-direction: column; gap: 12px; }
+.ink-price-card h3 { font-family: 'Playfair Display', serif; color: #effff6; letter-spacing: 0.08em; }
+.ink-price-card ul { list-style: none; padding-left: 0; display: grid; gap: 8px; color: #b8eccb; }
+.ink-price-card ul li::before { content: ""; display: inline-block; width: 10px; height: 10px; margin-right: 10px; border-radius: 50%; background: linear-gradient(135deg, #64f5b3, #2ddc8d); box-shadow: 0 0 0 3px rgba(88, 236, 169, 0.18); }
+
+.ink-waiver { background: linear-gradient(160deg, rgba(26, 56, 41, 0.8), rgba(7, 20, 14, 0.9)); border: 1px solid rgba(95, 244, 174, 0.22); border-radius: 20px; padding: clamp(28px, 4vw, 42px); box-shadow: 0 22px 60px rgba(4, 18, 12, 0.5); }
+.ink-waiver h2 { font-family: 'Playfair Display', serif; color: #effff6; }
+.ink-waiver p { color: #b8eccb; }
+.ink-waiver ul { list-style: none; padding-left: 0; display: grid; gap: 12px; color: #daf7e7; }
+.ink-waiver ul li { position: relative; padding-left: 26px; }
+.ink-waiver ul li::before { content: ""; position: absolute; left: 0; top: 8px; width: 14px; height: 14px; border-radius: 6px; background: linear-gradient(135deg, #64f5b3, #2ddc8d); box-shadow: 0 0 0 2px rgba(88, 236, 169, 0.18); }
+.ink-waiver .ink-size-note { margin-top: 20px; font-style: italic; color: #c6f4d8; }
+.ink-waiver .ink-size-note a { color: #8afad1; text-decoration: underline; }
+.ink-waiver .ink-size-note a:hover,
+.ink-waiver .ink-size-note a:focus-visible { color: #b5ffd8; }
+
+#inkExperience .contact-form { background: rgba(7, 18, 12, 0.92); border: 1px solid rgba(95, 244, 174, 0.22); box-shadow: 0 22px 60px rgba(3, 14, 9, 0.52); }
+#inkExperience .contact-form h2 { color: #effff6; }
+#inkExperience .contact-form label { color: #d8f9e7; }
+#inkExperience .contact-form input,
+#inkExperience .contact-form select,
+#inkExperience .contact-form textarea { background: rgba(4, 14, 9, 0.92); border: 1px solid rgba(95, 244, 174, 0.22); color: #effff6; }
+#inkExperience .contact-form input:focus,
+#inkExperience .contact-form select:focus,
+#inkExperience .contact-form textarea:focus { border-color: #64f5b3; box-shadow: 0 0 0 2px rgba(100, 245, 179, 0.22); }
+#inkExperience .contact-form button { background: linear-gradient(90deg, #64f5b3, #2ddc8d); color: #04291c; }
+
+.ink-consent-group { display: grid; gap: 12px; margin: 18px 0 24px; }
+.ink-checkbox { display: flex; gap: 10px; align-items: flex-start; font-size: 15px; color: #c2f2d7; }
+.ink-checkbox input { width: 18px; height: 18px; margin-top: 3px; accent-color: #36dd8d; }
+
+.ink-meta { margin-top: 28px; background: rgba(6, 16, 11, 0.9); border: 1px solid rgba(95, 244, 174, 0.18); border-radius: 18px; padding: clamp(20px, 3vw, 28px); color: #c2f2d7; box-shadow: 0 16px 44px rgba(3, 12, 8, 0.45); }
+.ink-meta h3 { margin-top: 0; font-family: 'Playfair Display', serif; color: #f0fff7; letter-spacing: 0.06em; }
+.ink-meta .contact-meta { color: #c2f2d7; }
+.ink-meta .contact-meta a { color: #8afad1; }
+.ink-meta .contact-meta a:hover,
+.ink-meta .contact-meta a:focus-visible { color: #b5ffd8; }
+.ink-prep { margin-top: 16px; color: #b9eacc; font-size: 15px; }
+
+body.experience-ink .experience-pill[data-switch-experience="interiors"],
+body.experience-ink .experience-pill[data-switch-experience="security"] { background: rgba(100, 245, 179, 0.14); border-color: rgba(100, 245, 179, 0.3); color: #e9fff4; }
+
+body.experience-ink #scrollProgress { background: linear-gradient(90deg, #64f5b3, #2ddc8d); box-shadow: 0 0 12px rgba(41, 220, 141, 0.45); }
+
+body.experience-ink .menu-toggle span { background: #aafbdc; }
+
 .grad-text{ background: linear-gradient(92deg,#ffffff 0%, #e1f0e7 35%, #ffb547 80%); -webkit-background-clip:text; background-clip:text; color:transparent; }
 
 .hero-jeton { background: radial-gradient(900px 500px at -10% -10%, rgba(255,122,24,.25), transparent 60%), radial-gradient(700px 400px at 110% -20%, rgba(255,181,71,.18), transparent 60%), linear-gradient(180deg, #0b0d12, #0f1217); box-shadow: inset 0 0 0 1px rgba(255,255,255,.06); }
@@ -1089,6 +1169,8 @@ body.experience-security .menu-toggle span{ background:#9fe8f5; }
   body.nav-open #siteNav{ display:flex; }
   #securityNav{ position: fixed; top:70px; left:50%; transform:translateX(-50%); width:min(92vw, 680px); background: rgba(7,14,18,.95); border:1px solid rgba(34,255,215,.22); border-radius:14px; padding:10px; display:none; flex-wrap:wrap; gap:8px; justify-content:center; z-index:1200; }
   body.nav-open-security #securityNav{ display:flex; }
+  #inkNav{ position: fixed; top:70px; left:50%; transform:translateX(-50%); width:min(92vw, 680px); background: rgba(9,24,16,.95); border:1px solid rgba(95,244,174,.24); border-radius:14px; padding:10px; display:none; flex-wrap:wrap; gap:8px; justify-content:center; z-index:1200; }
+  body.nav-open-ink #inkNav{ display:flex; }
 }
 
 /* Principles */


### PR DESCRIPTION
## Summary
- add Ømnilon Ink as a third experience with hero, pricing, waiver, and booking form
- implement custom green gradient styling and SVG size reference for the tattoo tiering
- update selector logic to support three experiences and mobile navigation for the new page

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dffad5f85c832186ae3855c36a4206