### PR TITLE
Add REO Clean Outs service + pricing estimator; update company phone to 404-769-2868

### DIFF
--- a/Payment.html
+++ b/Payment.html
@@ -60,6 +60,7 @@
                 <option value="New Build &amp; Renovation" data-price="5200">New Build &amp; Renovation</option>
                 <option value="Designer On Call" data-price="300">Designer On Call (2 hr block)</option>
                 <option value="Custom Furniture Sourcing" data-price="600">Custom Furniture Sourcing</option>
+                <option value="REO Clean Outs (Average)" data-price="1900">REO Clean Outs (Average)</option>
               </select>
             </div>
 

--- a/data/services.json
+++ b/data/services.json
@@ -1,41 +1,81 @@
 {
   "core": [
     {
-      "name": "E‑Design (Virtual)",
-      "desc": "A fast, mood‑board‑to‑makeover plan you can execute on your timeline—layout, palette, shoppable list, and a step‑by‑step setup guide.",
+      "name": "E\u2011Design (Virtual)",
+      "desc": "A fast, mood\u2011board\u2011to\u2011makeover plan you can execute on your timeline\u2014layout, palette, shoppable list, and a step\u2011by\u2011step setup guide.",
       "price": 450
     },
     {
       "name": "Residential Room Refresh",
-      "desc": "A precision tune‑up for one room—new paint and lighting, scaled furniture, curated textiles, and styling that makes what you already own feel intentional.",
+      "desc": "A precision tune\u2011up for one room\u2014new paint and lighting, scaled furniture, curated textiles, and styling that makes what you already own feel intentional.",
       "priceFrom": 1500
     },
     {
       "name": "Full Residential Design (Turnkey)",
-      "desc": "Concept through install—materials, custom pieces, trades and deliveries handled for you—so you leave a ‘before’ and come home to the ‘after.’",
+      "desc": "Concept through install\u2014materials, custom pieces, trades and deliveries handled for you\u2014so you leave a \u2018before\u2019 and come home to the \u2018after.\u2019",
       "priceFrom": 5000
     },
     {
       "name": "Home Staging",
-      "desc": "Market‑ready rooms styled to photograph beautifully and show even better—edited furniture, art, and accents that spotlight light, space, and flow.",
+      "desc": "Market\u2011ready rooms styled to photograph beautifully and show even better\u2014edited furniture, art, and accents that spotlight light, space, and flow.",
       "priceFrom": 2500
     },
     {
       "name": "Small Commercial / Boutique",
-      "desc": "Brand‑minded interiors for salons, cafés, and studios—optimized floor plans, durable finishes, and ‘stop‑and‑shoot’ moments that convert foot traffic.",
+      "desc": "Brand\u2011minded interiors for salons, caf\u00e9s, and studios\u2014optimized floor plans, durable finishes, and \u2018stop\u2011and\u2011shoot\u2019 moments that convert foot traffic.",
       "priceFrom": 7500
+    },
+    {
+      "name": "REO Clean Outs",
+      "desc": "Vacant-property clean out service for REO portfolios. Average market pricing is about $1.28/sq ft, while our competitive rate range is typically $0.88\u2013$1.42/sq ft depending on condition and haul-away volume.",
+      "priceFrom": 1200
     }
   ],
   "addons": [
-    {"name":"Move‑In Styling","desc":"Unpack, edit, and arrange what you own—then layer key pieces for a finished, livable feel by your first weekend in.","priceFrom":200},
-    {"name":"Paint & Color Direction","desc":"A cohesive palette for walls, trim, ceilings, and key finishes—with sheen specs and room‑by‑room placement so painters just roll.","priceFrom":200},
-    {"name":"Personal Sourcing Day","desc":"A designer on your arm—showrooms to checkout—pulling options, securing trade pricing, and leaving you with a ready‑to‑order cart.","priceFrom":75},
-    {"name":"Art Curation & Gallery Walls","desc":"A curated art plan with scaled mockups and a hanging map—so every piece lands at the right height and tells the right story.","priceFrom":200},
-    {"name":"Holiday / Event Styling","desc":"One‑day transformation for photos, parties, or rentals—tablescapes, mantel moments, florals, and layered lighting you can recreate next season.","priceFrom":500},
-    {"name":"Space Planning & Layout","desc":"Scaled floor plans that unlock sightlines and circulation—right‑sized furniture, clear dimensions, and a map for confident buying.","priceFrom":200},
-    {"name":"Finish & Fixture Selections (Kitchen/Bath)","desc":"Clean, cohesive specs—countertops, tile, plumbing, hardware, and paint that play together beautifully from sample to install.","priceFrom":200},
-    {"name":"Lighting Plan","desc":"Ambient, task, and accent layers plotted room by room—with fixture types, counts, and switch logic for flattering, functional light.","priceFrom":200},
-    {"name":"Window Treatments","desc":"Tailored drapery and shades—fabric and hardware pairings, measurements, and privacy/light control calibrated to each room.","priceFrom":200}
+    {
+      "name": "Move\u2011In Styling",
+      "desc": "Unpack, edit, and arrange what you own\u2014then layer key pieces for a finished, livable feel by your first weekend in.",
+      "priceFrom": 200
+    },
+    {
+      "name": "Paint & Color Direction",
+      "desc": "A cohesive palette for walls, trim, ceilings, and key finishes\u2014with sheen specs and room\u2011by\u2011room placement so painters just roll.",
+      "priceFrom": 200
+    },
+    {
+      "name": "Personal Sourcing Day",
+      "desc": "A designer on your arm\u2014showrooms to checkout\u2014pulling options, securing trade pricing, and leaving you with a ready\u2011to\u2011order cart.",
+      "priceFrom": 75
+    },
+    {
+      "name": "Art Curation & Gallery Walls",
+      "desc": "A curated art plan with scaled mockups and a hanging map\u2014so every piece lands at the right height and tells the right story.",
+      "priceFrom": 200
+    },
+    {
+      "name": "Holiday / Event Styling",
+      "desc": "One\u2011day transformation for photos, parties, or rentals\u2014tablescapes, mantel moments, florals, and layered lighting you can recreate next season.",
+      "priceFrom": 500
+    },
+    {
+      "name": "Space Planning & Layout",
+      "desc": "Scaled floor plans that unlock sightlines and circulation\u2014right\u2011sized furniture, clear dimensions, and a map for confident buying.",
+      "priceFrom": 200
+    },
+    {
+      "name": "Finish & Fixture Selections (Kitchen/Bath)",
+      "desc": "Clean, cohesive specs\u2014countertops, tile, plumbing, hardware, and paint that play together beautifully from sample to install.",
+      "priceFrom": 200
+    },
+    {
+      "name": "Lighting Plan",
+      "desc": "Ambient, task, and accent layers plotted room by room\u2014with fixture types, counts, and switch logic for flattering, functional light.",
+      "priceFrom": 200
+    },
+    {
+      "name": "Window Treatments",
+      "desc": "Tailored drapery and shades\u2014fabric and hardware pairings, measurements, and privacy/light control calibrated to each room.",
+      "priceFrom": 200
+    }
   ]
 }
-

--- a/index.html
+++ b/index.html
@@ -115,6 +115,35 @@
                         <h3>Small Commercial</h3>
                         <p>Warm, durable finishes and layouts for boutiques, coffee shops, and creative offices.</p>
                     </article>
+                    <article class="feature ledger-card hud-bracket fx-rise">
+                        <h3>REO Clean Outs</h3>
+                        <p>Bank-ready property clean outs with debris removal, broom-swept finishes, and photo documentation for disposition teams.</p>
+                    </article>
+                </section>
+
+                <section id="reo-pricing" class="section ledger-card fx-rise">
+                    <h2>REO Clean Out pricing estimator</h2>
+                    <p>Average market pricing runs <strong>$0.95–$1.60 per sq ft</strong>. OmniLend's competitive range is typically <strong>$0.88–$1.42 per sq ft</strong> based on volume and access.</p>
+                    <div class="payment-grid">
+                        <div>
+                            <label for="reoSqft">Estimated square footage</label>
+                            <input type="number" id="reoSqft" min="400" step="50" value="1200" />
+                        </div>
+                        <div>
+                            <label for="reoComplexity">Property condition</label>
+                            <select id="reoComplexity">
+                                <option value="0.9">Light clean out</option>
+                                <option value="1" selected>Standard clean out</option>
+                                <option value="1.15">Heavy debris / bulky haul-away</option>
+                            </select>
+                        </div>
+                    </div>
+                    <p id="reoEstimate" class="finance-meta-note" aria-live="polite"></p>
+                    <ul>
+                        <li><strong>Average market total:</strong> Benchmark generated from sqft × $1.28 median rate.</li>
+                        <li><strong>OmniLend competitive range:</strong> Calculated from sqft × $0.88 to $1.42, then adjusted by property condition.</li>
+                        <li><strong>Volume discount:</strong> 8% off when 3+ properties are scheduled in one cycle.</li>
+                    </ul>
                 </section>
 
                 <section id="portfolio" class="section gallery-grid features-ledger">
@@ -217,6 +246,7 @@
                             <option value="Residential Refresh">Residential Refresh</option>
                             <option value="Staging">Staging</option>
                             <option value="Small Commercial">Small Commercial</option>
+                            <option value="REO Clean Outs">REO Clean Outs</option>
                             <option value="Unsure">Unsure</option>
                         </select>
                         <label for="interiorBudget">Budget Range:</label>
@@ -242,7 +272,7 @@
                     <p class="form-status" data-form-status aria-live="polite" role="status"></p>
                     <ul class="contact-meta">
                         <li>Email: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
-                        <li>Phone: <a href="tel:4049198026">404-919-8026</a></li>
+                        <li>Phone: <a href="tel:4047692868">404-769-2868</a></li>
                         <li>Hours: Mon–Fri, 8am–6pm ET</li>
                     </ul>
                 </section>
@@ -435,7 +465,7 @@
                     <p class="form-status" data-form-status aria-live="polite" role="status"></p>
                     <ul class="contact-meta">
                         <li>Security desk: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
-                        <li>Direct line: <a href="tel:4049198026">404-919-8026</a></li>
+                        <li>Direct line: <a href="tel:4047692868">404-769-2868</a></li>
                         <li>Rapid response: 7 days, 6am–10pm ET for active investigations.</li>
                     </ul>
                 </section>
@@ -620,7 +650,7 @@
                         <h3>Studio details</h3>
                         <ul class="contact-meta">
                             <li>Email: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
-                            <li>Text line: <a href="tel:4049198026">404-919-8026</a></li>
+                            <li>Text line: <a href="tel:4047692868">404-769-2868</a></li>
                             <li>Studio: Atlanta, GA (exact address provided after booking)</li>
                             <li>Follow apprentice progress: <a href="https://www.instagram.com/" target="_blank" rel="noopener">Instagram updates</a></li>
                         </ul>
@@ -824,7 +854,7 @@
                         <h3>Finance desk</h3>
                         <ul class="contact-meta">
                             <li>Email: <a href="mailto:omnilend.co@gmail.com">omnilend.co@gmail.com</a></li>
-                            <li>Phone: <a href="tel:4049198026">404-919-8026</a></li>
+                            <li>Phone: <a href="tel:4047692868">404-769-2868</a></li>
                             <li>Availability: Mon–Sat, 8am–8pm ET</li>
                         </ul>
                         <p class="finance-meta-note">We’ll configure an America's First Finance-ready rollout for phones, laptops, computers, PCs, scooters, and mopeds.</p>

--- a/script.js
+++ b/script.js
@@ -747,3 +747,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
     update();
 });
+
+// REO clean-out pricing estimator
+document.addEventListener('DOMContentLoaded', () => {
+    const sqftInput = document.getElementById('reoSqft');
+    const complexitySelect = document.getElementById('reoComplexity');
+    const estimateEl = document.getElementById('reoEstimate');
+    if (!sqftInput || !complexitySelect || !estimateEl) return;
+
+    const money = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+    const renderEstimate = () => {
+        const sqft = Math.max(0, Number(sqftInput.value) || 0);
+        const factor = Number(complexitySelect.value) || 1;
+        const marketAverage = sqft * 1.28 * factor;
+        const compLow = sqft * 0.88 * factor;
+        const compHigh = sqft * 1.42 * factor;
+
+        estimateEl.innerHTML = `Estimated average market total: <strong>${money.format(marketAverage)}</strong>. Competitive OmniLend range: <strong>${money.format(compLow)}–${money.format(compHigh)}</strong>.`;
+    };
+
+    sqftInput.addEventListener('input', renderEstimate);
+    complexitySelect.addEventListener('change', renderEstimate);
+    renderEstimate();
+});

--- a/site/content/omnilend.ts
+++ b/site/content/omnilend.ts
@@ -74,7 +74,7 @@ export const omniContent = {
     heroLabel: "OmniLend // Integrated Systems",
     heroTitle: "One system",
     heroSubtitle:
-      "Choose the lane you need: interiors, finance, protection, or ink. Each service now has its own dedicated page with a lighter path to booking.",
+      "Choose the lane you need: interiors, REO clean outs, finance, protection, or ink. Each service now has its own dedicated page with a lighter path to booking.",
     heroCtaPrimary: "Browse services",
     heroCtaSecondary: "Start contact",
     heroHighlights: [
@@ -104,7 +104,7 @@ export const omniContent = {
   ] as SectionNav[],
   overview: {
     eyebrow: "System overview",
-    title: "Four services, one operating partner.",
+    title: "Five services, one operating partner.",
     subtitle:
       "Use the homepage as a directory, then move into the service page that matches the work you actually need.",
     items: [
@@ -195,6 +195,26 @@ export const omniContent = {
         pricing: "Engagement: assessment plus ongoing review",
         accent: "#59D3B2",
         accentSoft: "rgba(89, 211, 178, 0.18)"
+      },
+      {
+        id: "reo-clean-outs",
+        title: "REO Clean Outs",
+        summary: "Vacant-property clean outs for lenders, servicers, and disposition teams.",
+        description:
+          "We coordinate clean outs, debris haul-away, broom-swept finishing, and photo documentation so REO assets are ready for market quickly.",
+        outcomes: [
+          "Faster market readiness",
+          "Clear scope and documentation",
+          "Predictable per-property pricing"
+        ],
+        deliverables: [
+          "Initial condition assessment",
+          "Debris removal and disposal logs",
+          "Completion photos and turnover checklist"
+        ],
+        pricing: "Average market rate ≈ $1.28/sq ft; OmniLend competitive range: $0.88–$1.42/sq ft",
+        accent: "#77B6EA",
+        accentSoft: "rgba(119, 182, 234, 0.18)"
       },
       {
         id: "ink-studio",
@@ -360,8 +380,8 @@ export const omniContent = {
     subtitle:
       "Share your goals across design, finance, or protection. We will respond with a tailored plan.",
     email: "omnilend.co@gmail.com",
-    phone: "(470) 210-4341",
-    phoneDial: "+14702104341",
+    phone: "(404) 769-2868",
+    phoneDial: "+14047692868",
     availability: "New engagements accepted quarterly.",
     formTitle: "Start an engagement",
     formDescription: "Send a brief note and we will follow up within 2 business days.",

--- a/site/content/omnilend.ts
+++ b/site/content/omnilend.ts
@@ -67,8 +67,8 @@ export const omniContent = {
     url: "https://omnilend.pro",
     title: "OmniLend - Interiors, Fortification, Tattoos & Financing",
     description:
-      "OmniLend offers four lanes in one place: interiors, asset fortification, tattoos, and consumer financing powered by America's First Finance.",
-    tagline: "Interiors. Fortification. Tattoos. Financing.",
+      "OmniLend offers five lanes in one place: interiors, REO clean-outs, asset fortification, tattoos, and consumer financing powered by America's First Finance.",
+    tagline: "Interiors. REO Clean-Outs. Fortification. Tattoos. Financing.",
     gatewayTagline: "OMNILEND // SYSTEM ENTRY",
     introLabel: "System access",
     heroLabel: "OmniLend // Integrated Systems",
@@ -79,6 +79,7 @@ export const omniContent = {
     heroCtaSecondary: "Start contact",
     heroHighlights: [
       "Interior design + experience",
+      "REO clean-outs + turnover",
       "Financial clarity + planning",
       "Asset protection + safety",
       "Operational alignment"
@@ -117,6 +118,11 @@ export const omniContent = {
         title: "Finance operations",
         description:
           "Planning, forecasting, and cash flow visibility that keeps teams aligned on growth and risk."
+      },
+      {
+        title: "REO clean-out operations",
+        description:
+          "Vacant-property clean-out coordination, debris removal, and disposition-ready turnover documentation."
       },
       {
         title: "Asset protection",

--- a/site/content/pages/contact.mdx
+++ b/site/content/pages/contact.mdx
@@ -11,7 +11,7 @@ sections:
       - title: "Email"
         body: "omnilend.co@gmail.com — best for portfolios, attachments, or sharing mood boards and intel briefs."
       - title: "Text / Phone"
-        body: "470-210-4341 — quick updates, booking confirmations, or day-of studio access."
+        body: "404-769-2868 — quick updates, booking confirmations, or day-of studio access."
       - title: "Secure form"
         body: "Use the form below to route inquiries directly to the right division with captcha protection."
   - type: steps
@@ -25,4 +25,4 @@ sections:
         body: "We schedule install dates, Secret Lifter deployments, or tattoo appointments and keep you updated."
 ---
 
-You can drop a line at **omnilend.co@gmail.com**, text **470-210-4341**, or outline everything through the booking forms. Interiors projects are available nationwide (Atlanta-based install team). Secret Lifter audits cover single sites through national portfolios. Ømnilon Ink sessions run out of Atlanta—with the exact studio address shared after deposits clear.
+You can drop a line at **omnilend.co@gmail.com**, text **404-769-2868**, or outline everything through the booking forms. Interiors projects are available nationwide (Atlanta-based install team). Secret Lifter audits cover single sites through national portfolios. Ømnilon Ink sessions run out of Atlanta—with the exact studio address shared after deposits clear.

--- a/site/src/components/BrandPage.tsx
+++ b/site/src/components/BrandPage.tsx
@@ -932,10 +932,10 @@ export function BrandPage({ initialExperience = "interiors", skipIntro = false }
                       </a>{" "}
                       or call{" "}
                       <a
-                        href="tel:14702104341"
+                        href="tel:14047692868"
                         className="underline decoration-dotted underline-offset-4 hover:text-white"
                       >
-                        470-210-4341
+                        404-769-2868
                       </a>
                       . {cta.body}
                     </p>

--- a/site/src/components/ExperienceDeck.tsx
+++ b/site/src/components/ExperienceDeck.tsx
@@ -278,10 +278,10 @@ export function ExperienceDeck({ activeId, onSelect }: ExperienceDeckProps) {
               </a>{" "}
               or call{" "}
               <a
-                href="tel:14702104341"
+                href="tel:14047692868"
                 className="underline decoration-dotted underline-offset-4 hover:text-white"
               >
-                470-210-4341
+                404-769-2868
               </a>
               .
             </p>

--- a/site/src/components/experience/sections/Contact.tsx
+++ b/site/src/components/experience/sections/Contact.tsx
@@ -147,7 +147,7 @@ export function Contact({ showLaneCards = true }: { showLaneCards?: boolean }) {
                     name="phone"
                     autoComplete="tel"
                     className="omni-input"
-                    placeholder="(470) 210-4341"
+                    placeholder="(404) 769-2868"
                   />
                 </div>
                 <div className="omni-form-field">


### PR DESCRIPTION
### Motivation
- Introduce a new REO clean-out offering with quick pricing guidance so prospects and disposition teams can estimate costs on-site.  
- Standardize the company contact number across the static site and Next.js components to the requested `404-769-2868` for consistent outreach.

### Description
- Added a new `REO Clean Outs` service card on the homepage and included `REO Clean Outs` in the interiors contact form service dropdown in `index.html`.  
- Implemented a dedicated `#reo-pricing` section with inputs for square footage and property condition and added a selectable `REO Clean Outs (Average)` option to the payment selector in `Payment.html`.  
- Added estimator logic to `script.js` that computes market-average and OmniLend competitive ranges using `sqft × 1.28` (market) and `sqft × 0.88–1.42` (competitive) adjusted by condition factor.  
- Updated structured service data in `data/services.json` and site content in `site/content/omnilend.ts` to include the REO service and pricing guidance, and updated `site/content/pages/contact.mdx` and Next.js components (`BrandPage.tsx`, `ExperienceDeck.tsx`, `experience/sections/Contact.tsx`) to use `404-769-2868` and the new `phoneDial` value.

### Testing
- Ran `node -c script.js` to validate the client-side script syntax and it succeeded.  
- Verified `data/services.json` is valid JSON with `python -m json.tool data/services.json` and it succeeded.  
- Ran the site linter with `npm --prefix site run -s lint` and it reported no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2d178f588321b2b1038b5fe798ca)